### PR TITLE
Add CI test for Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,11 +57,18 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake Windows
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_BIN_DIR="c:/vcpkg/installed/x64-windows/bin"
 
       - name: Build
-        run: msbuild
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: cmake --build . --config $BUILD_TYPE
 
 #  macos-build:
 #     runs-on: macos-10.15

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,18 +57,11 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Create Build Environment
-        run: cmake -E make_directory ${{runner.workspace}}/build
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
 
-      - name: Configure CMake Windows
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-        
       - name: Build
-        working-directory: ${{runner.workspace}}/build
-        shell: bash
-        run: cmake --build . --config $BUILD_TYPE
+        run: msbuild
 
 #  macos-build:
 #     runs-on: macos-10.15

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,31 @@ jobs:
           CC: gcc-10
           CXX: g++-10
         run: cmake --build . --config $BUILD_TYPE
- 
+
+  win:
+    runs-on: windows-latest
+    name: 🟦 Windows x64
+    steps:
+
+      - name: 🧰 Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake Windows
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        
+      - name: Build
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: cmake --build . --config $BUILD_TYPE
+
 #  macos-build:
 #     runs-on: macos-10.15
 #     name: 🍎 macOS 10.15


### PR DESCRIPTION
This was missing from the previous PR. I think adding Windows is always useful, in preparation for adding tests that run in different platforms.