### PR TITLE
Add use of SSE2 on e2k (MCST Elbrus 2000) by default

### DIFF
--- a/UTEngine/Precomp.h
+++ b/UTEngine/Precomp.h
@@ -19,7 +19,7 @@
 #undef DrawText
 #endif
 
-#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || ((defined(__i386__) || defined(__x86_64__)) && defined(__SSE2__))
+#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) || ((defined(__i386__) || defined(__x86_64__) || defined(__e2k__)) && defined(__SSE2__))
 #else
 #define NOSSE
 #endif


### PR DESCRIPTION
MCST e2k (Elbrus 2000) architecture has half native / half software support of most Intel/AMD SIMD
e.g. MMX/SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2/AES/AVX/AVX2 & 3DNow!/SSE4a/XOP/FMA4

E2K - this is VLIW/EPIC architecture, like Intel Itanium (IA-64) architecture.
Ref: https://en.wikipedia.org/wiki/Elbrus_2000