### PR TITLE
Directory::localAppData(): Use getenv() to get the home folder instead

### DIFF
--- a/SurrealEngine/Utils/File.cpp
+++ b/SurrealEngine/Utils/File.cpp
@@ -401,7 +401,13 @@ void Directory::create(const std::string& dirname)
 
 std::string Directory::localAppData()
 {
-	return "~/.config";
+	// We're trying to find "~/.config" here
+	const char* homeDir = getenv("HOME");
+
+	if (!homeDir)
+		throw std::runtime_error("HOME environment variable is not set... somehow.");
+
+	return FilePath::combine(std::string(homeDir), ".config");
 }
 
 #endif


### PR DESCRIPTION
Sadly we don't have the luxury of having ~ expand to user's home folder. We gotta do it the getenv() way.

This fixes the error upon starting up SE on Linux, saying that it cannot find the ~/.config folder.