### PR TITLE
Small changes for Unreal 227i

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,8 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/UObject/UDXSaveInfo.h
 	SurrealEngine/UObject/UDXTextParser.cpp
 	SurrealEngine/UObject/UDXTextParser.h
+	SurrealEngine/UObject/U227Emitter.cpp
+	SurrealEngine/UObject/U227Emitter.h
 	SurrealEngine/UObject/UClient.h
 	SurrealEngine/UObject/UMesh.cpp
 	SurrealEngine/UObject/UMesh.h

--- a/SurrealEngine/GameFolder.h
+++ b/SurrealEngine/GameFolder.h
@@ -14,6 +14,7 @@ struct GameLaunchInfo
 	bool IsUnreal1() const { return gameExecutableName == "Unreal"; }
 	bool IsUnreal1_226() const { return IsUnreal1() && engineVersion == 226; }
 	bool IsUnreal1_227() const { return IsUnreal1() && engineVersion == 227; }
+	bool IsUnreal1_227k() const { return IsUnreal1_227() && engineSubVersion == 11; }
 	bool IsUnrealTournament() const { return gameExecutableName == "UnrealTournament"; }
 	bool IsUnrealTournament_469() const { return IsUnrealTournament() && engineVersion == 469; }
 	bool IsDeusEx() const { return gameExecutableName == "DeusEx"; }

--- a/SurrealEngine/Native/NActor.cpp
+++ b/SurrealEngine/Native/NActor.cpp
@@ -16,7 +16,9 @@
 void NActor::RegisterFunctions()
 {
 	RegisterVMNativeFunc_3("Actor", "Add_ColorColor", &NActor::Add_ColorColor, 551);
-	if (engine->LaunchInfo.IsUnreal1_227())
+	if (engine->LaunchInfo.IsUnreal1_227k())
+		RegisterVMNativeFunc_5("Actor", "AllActors", &NActor::AllActors_U227k, 304);
+	else if (engine->LaunchInfo.IsUnreal1_227())
 		RegisterVMNativeFunc_5("Actor", "AllActors", &NActor::AllActors_U227, 304);
 	else
 		RegisterVMNativeFunc_3("Actor", "AllActors", &NActor::AllActors, 304);
@@ -131,7 +133,12 @@ void NActor::AllActors(UObject* Self, UObject* BaseClass, UObject*& Actor, std::
 	Frame::CreatedIterator = std::make_unique<AllActorsIterator>(BaseClass, &Actor, MatchTag ? *MatchTag : std::string());
 }
 
-void NActor::AllActors_U227(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent, bool bAllLevels)
+void NActor::AllActors_U227(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent)
+{
+	Frame::CreatedIterator = std::make_unique<AllActorsIterator>(BaseClass, &Actor, MatchTag ? *MatchTag : std::string(), MatchEvent ? *MatchEvent : std::string(), false);
+}
+
+void NActor::AllActors_U227k(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent, bool bAllLevels)
 {
 	Frame::CreatedIterator = std::make_unique<AllActorsIterator>(BaseClass, &Actor, MatchTag ? *MatchTag : std::string(), MatchEvent ? *MatchEvent : std::string(), bAllLevels);
 }

--- a/SurrealEngine/Native/NActor.h
+++ b/SurrealEngine/Native/NActor.h
@@ -9,7 +9,8 @@ public:
 
 	static void Add_ColorColor(const Color& A, const Color& B, Color& ReturnValue);
 	static void AllActors(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag);
-	static void AllActors_U227(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent, bool bAllLevels);
+	static void AllActors_U227(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent);
+	static void AllActors_U227k(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent, bool bAllLevels);
 	static void AutonomousPhysics(UObject* Self, float DeltaSeconds);
 	static void BasedActors(UObject* Self, UObject* BaseClass, UObject*& Actor);
 	static void ChildActors(UObject* Self, UObject* BaseClass, UObject*& Actor);

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -28,6 +28,7 @@
 #include "UObject/UWindow.h"
 #include "UObject/UFlag.h"
 #include "UObject/UConSys.h"
+#include "UObject/U227Emitter.h"
 #include "VM/NativeFunc.h"
 #include "Native/NActor.h"
 #include "Native/NCanvas.h"
@@ -862,6 +863,7 @@ void PackageManager::RegisterFunctions()
 void PackageManager::RegisterNativeClasses()
 {
 	NameString corePackage = "Core";
+	NameString emitterPackage = "Emitter";
 	NameString enginePackage = "Engine";
 	NameString ipdrvPackage = "IpDrv";
 	NameString upakPackage = "UPak";
@@ -1028,6 +1030,20 @@ void PackageManager::RegisterNativeClasses()
 	{
 		RegisterNativeClass<UPakPathNodeIterator>(upakPackage, "PathNodeIterator", "Actor");
 		RegisterNativeClass<UPakPawnPathNodeIterator>(upakPackage, "PawnPathNodeIterator", "PathNodeIterator");
+	}
+
+	if (IsUnreal1_227())
+	{
+		RegisterNativeClass<UStaticMesh>(enginePackage, "StaticMesh", "Mesh");
+		RegisterNativeClass<UEmitterRC>(emitterPackage, "EmitterRC", "Actor");
+		RegisterNativeClass<UXParticleEmitter>(emitterPackage, "XParticleEmitter", "Actor");
+		RegisterNativeClass<UXParticleForces>(emitterPackage, "XParticleForces", "Actor");
+		RegisterNativeClass<UVelocityForce>(emitterPackage, "VelocityForce", "XParticleForces");
+		RegisterNativeClass<UKillParticleForce>(emitterPackage, "KillParticleForce", "XParticleForces");
+		RegisterNativeClass<UParticleConcentrateForce>(emitterPackage, "ParticleConcentrateForce", "XParticleForces");
+		RegisterNativeClass<UXEmitter>(emitterPackage, "XEmitter", "XParticleEmitter");
+		RegisterNativeClass<UXTrailParticle>(emitterPackage, "XTrailParticle", "Actor");
+		RegisterNativeClass<UXBeamEmitter>(emitterPackage, "XBeamEmitter", "XEmitter");
 	}
 	
 	if (IsDeusEx())

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -37,6 +37,7 @@ public:
 	bool IsUnreal1() const { return launchInfo.IsUnreal1(); }
 	bool IsUnreal1_226() const { return launchInfo.IsUnreal1_226(); }
 	bool IsUnreal1_227() const { return launchInfo.IsUnreal1_227(); }
+	bool IsUnreal1_227k() const { return launchInfo.IsUnreal1_227k(); }
 	bool IsUnrealTournament() const { return launchInfo.IsUnrealTournament(); }
 	bool IsUnrealTournament_469() const { return launchInfo.IsUnrealTournament_469(); }
 	bool IsDeusEx() const { return launchInfo.IsDeusEx(); }

--- a/SurrealEngine/UObject/PropertyOffsets.cpp
+++ b/SurrealEngine/UObject/PropertyOffsets.cpp
@@ -4744,6 +4744,249 @@ static void InitPropertyOffsets_TabGroupWindow(PackageManager* packages)
 	PropOffsets_TabGroupWindow.tabGroupIndex = cls->GetPropertyDataOffset("tabGroupIndex");
 }
 
+PropertyOffsets_XParticleEmitter PropOffsets_XParticleEmitter;
+
+static void InitPropertyOffsets_XParticleEmitter(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Emitter")->GetUObject("Class", "XParticleEmitter"));
+	if (!cls)
+	{
+		memset(&PropOffsets_XParticleEmitter, 0xff, sizeof(PropOffsets_XParticleEmitter));
+		return;
+	}
+	PropOffsets_XParticleEmitter.ActiveCount = cls->GetPropertyDataOffset("ActiveCount");
+	PropOffsets_XParticleEmitter.bHasInitilized = cls->GetPropertyDataOffset("bHasInitilized"); // sic
+	PropOffsets_XParticleEmitter.bKillNextTick = cls->GetPropertyDataOffset("bKillNextTick");
+	PropOffsets_XParticleEmitter.bHasSpecialParts = cls->GetPropertyDataOffset("bHasSpecialParts");
+	PropOffsets_XParticleEmitter.bWasPostDestroyed = cls->GetPropertyDataOffset("bWasPostDestroyed");
+	PropOffsets_XParticleEmitter.bHasInitView = cls->GetPropertyDataOffset("bHasInitView");
+	PropOffsets_XParticleEmitter.PartCombiners = cls->GetPropertyDataOffset("PartCombiners");
+	PropOffsets_XParticleEmitter.bUSNotifyParticles = cls->GetPropertyDataOffset("bUSNotifyParticles");
+	PropOffsets_XParticleEmitter.bNotifyNetReceive = cls->GetPropertyDataOffset("bNotifyNetReceive");
+	PropOffsets_XParticleEmitter.bUSModifyParticles = cls->GetPropertyDataOffset("bUSModifyParticles");
+	PropOffsets_XParticleEmitter.bNotOnPortals = cls->GetPropertyDataOffset("bNotOnPortals");
+}
+
+PropertyOffsets_XEmitter PropOffsets_XEmitter;
+
+static void InitPropertyOffsets_XEmitter(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Emitter")->GetUObject("Class", "XEmitter"));
+	if (!cls)
+	{
+		memset(&PropOffsets_XEmitter, 0xff, sizeof(PropOffsets_XEmitter));
+		return;
+	}
+	PropOffsets_XEmitter.AutoResetTime = cls->GetPropertyDataOffset("AutoResetTime");
+	PropOffsets_XEmitter.bAccelRelativeToRot = cls->GetPropertyDataOffset("bAccelRelativeToRot");
+	PropOffsets_XEmitter.BACKUP_Disabled = cls->GetPropertyDataOffset("BACKUP_Disabled");
+	PropOffsets_XEmitter.bActorsBlockSight = cls->GetPropertyDataOffset("bActorsBlockSight");
+	PropOffsets_XEmitter.bAutoDestroy = cls->GetPropertyDataOffset("bAutoDestroy");
+	PropOffsets_XEmitter.bAutoReset = cls->GetPropertyDataOffset("bAutoReset");
+	PropOffsets_XEmitter.bAutoVisibilityBox = cls->GetPropertyDataOffset("bAutoVisibilityBox");
+	PropOffsets_XEmitter.bBoxVisibility = cls->GetPropertyDataOffset("bBoxVisibility");
+	PropOffsets_XEmitter.bCheckLineOfSight = cls->GetPropertyDataOffset("bCheckLineOfSight");
+	PropOffsets_XEmitter.bCOffsetRelativeToRot = cls->GetPropertyDataOffset("bCOffsetRelativeToRot");
+	PropOffsets_XEmitter.bCylRangeBasedOnPos = cls->GetPropertyDataOffset("bCylRangeBasedOnPos");
+	PropOffsets_XEmitter.bDestruction = cls->GetPropertyDataOffset("bDestruction");
+	PropOffsets_XEmitter.bDisabled = cls->GetPropertyDataOffset("bDisabled");
+	PropOffsets_XEmitter.bDisableRender = cls->GetPropertyDataOffset("bDisableRender");
+	PropOffsets_XEmitter.bDistanceCulling = cls->GetPropertyDataOffset("bDistanceCulling");
+	PropOffsets_XEmitter.bEffectsVelocity = cls->GetPropertyDataOffset("bEffectsVelocity");
+	PropOffsets_XEmitter.bGradualSpawnCoords = cls->GetPropertyDataOffset("bGradualSpawnCoords");
+	PropOffsets_XEmitter.bHasAliveParticles = cls->GetPropertyDataOffset("bHasAliveParticles");
+	PropOffsets_XEmitter.bHasLossVel = cls->GetPropertyDataOffset("bHasLossVel");
+	PropOffsets_XEmitter.bNoUpdateOnInvis = cls->GetPropertyDataOffset("bNoUpdateOnInvis");
+	PropOffsets_XEmitter.bParticleCoronaEnabled = cls->GetPropertyDataOffset("bParticleCoronaEnabled");
+	PropOffsets_XEmitter.bRelativeToRotation = cls->GetPropertyDataOffset("bRelativeToRotation");
+	PropOffsets_XEmitter.bRespawnParticles = cls->GetPropertyDataOffset("bRespawnParticles");
+	PropOffsets_XEmitter.bRevolutionEnabled = cls->GetPropertyDataOffset("bRevolutionEnabled");
+	PropOffsets_XEmitter.bRotationRequest = cls->GetPropertyDataOffset("bRotationRequest");
+	PropOffsets_XEmitter.bSpawnInitParticles = cls->GetPropertyDataOffset("bSpawnInitParticles");
+	PropOffsets_XEmitter.bStatisEmitter = cls->GetPropertyDataOffset("bStatisEmitter");
+	PropOffsets_XEmitter.bUseMeshAnim = cls->GetPropertyDataOffset("bUseMeshAnim");
+	PropOffsets_XEmitter.bUseRandomTex = cls->GetPropertyDataOffset("bUseRandomTex");
+	PropOffsets_XEmitter.bUseRelativeLocation = cls->GetPropertyDataOffset("bUseRelativeLocation");
+	PropOffsets_XEmitter.bVelRelativeToRotation = cls->GetPropertyDataOffset("bVelRelativeToRotation");
+	PropOffsets_XEmitter.BoxLocation = cls->GetPropertyDataOffset("BoxLocation");
+	PropOffsets_XEmitter.BoxVelocity = cls->GetPropertyDataOffset("BoxVelocity");
+	PropOffsets_XEmitter.CacheRot = cls->GetPropertyDataOffset("CacheRot");
+	PropOffsets_XEmitter.ColorScaleCount = cls->GetPropertyDataOffset("ColorScaleCount");
+	PropOffsets_XEmitter.CombinedParticleCount = cls->GetPropertyDataOffset("CombinedParticleCount");
+	PropOffsets_XEmitter.CoronaColor = cls->GetPropertyDataOffset("CoronaColor");
+	PropOffsets_XEmitter.CoronaFadeTimeScale = cls->GetPropertyDataOffset("CoronaFadeTimeScale");
+	PropOffsets_XEmitter.CoronaMaxScale = cls->GetPropertyDataOffset("CoronaMaxScale");
+	PropOffsets_XEmitter.CoronaOffset = cls->GetPropertyDataOffset("CoronaOffset");
+	PropOffsets_XEmitter.CoronaScaling = cls->GetPropertyDataOffset("CoronaScaling");
+	PropOffsets_XEmitter.CoronaTexture = cls->GetPropertyDataOffset("CoronaTexture");
+	PropOffsets_XEmitter.CullDistance = cls->GetPropertyDataOffset("CullDistance");
+	PropOffsets_XEmitter.CullDistanceFadeDist = cls->GetPropertyDataOffset("CullDistanceFadeDist");
+	PropOffsets_XEmitter.DestroySound = cls->GetPropertyDataOffset("DestroySound");
+	PropOffsets_XEmitter.DestructCombiners = cls->GetPropertyDataOffset("DestructCombiners");
+	PropOffsets_XEmitter.DrawScaleCount = cls->GetPropertyDataOffset("DrawScaleCount");
+	PropOffsets_XEmitter.FadeInMaxAmount = cls->GetPropertyDataOffset("FadeInMaxAmount");
+	PropOffsets_XEmitter.FadeInTime = cls->GetPropertyDataOffset("FadeInTime");
+	PropOffsets_XEmitter.FadeOutTime = cls->GetPropertyDataOffset("FadeOutTime");
+	PropOffsets_XEmitter.FinishedSpawningTrigger = cls->GetPropertyDataOffset("FinishedSpawningTrigger");
+	PropOffsets_XEmitter.ForcesList = cls->GetPropertyDataOffset("ForcesList");
+	PropOffsets_XEmitter.ForcesTags = cls->GetPropertyDataOffset("ForcesTags");
+	PropOffsets_XEmitter.HittingActorKickVelScale = cls->GetPropertyDataOffset("HittingActorKickVelScale");
+	PropOffsets_XEmitter.ImpactSound = cls->GetPropertyDataOffset("ImpactSound");
+	PropOffsets_XEmitter.LifeTimeCombiners = cls->GetPropertyDataOffset("LifeTimeCombiners");
+	PropOffsets_XEmitter.LifetimeRange = cls->GetPropertyDataOffset("LifetimeRange");
+	PropOffsets_XEmitter.LODFactor = cls->GetPropertyDataOffset("LODFactor");
+	PropOffsets_XEmitter.MaxCoronaDistance = cls->GetPropertyDataOffset("MaxCoronaDistance");
+	PropOffsets_XEmitter.MaxParticles = cls->GetPropertyDataOffset("MaxParticles");
+	PropOffsets_XEmitter.MinBounceVelocity = cls->GetPropertyDataOffset("MinBounceVelocity");
+	PropOffsets_XEmitter.MinImpactVelForSnd = cls->GetPropertyDataOffset("MinImpactVelForSnd");
+	PropOffsets_XEmitter.NextParticleTime = cls->GetPropertyDataOffset("NextParticleTime");
+	PropOffsets_XEmitter.OldSpawnPosition = cls->GetPropertyDataOffset("OldSpawnPosition");
+	PropOffsets_XEmitter.ParticleAcceleration = cls->GetPropertyDataOffset("ParticleAcceleration");
+	PropOffsets_XEmitter.ParticleBounchyness = cls->GetPropertyDataOffset("ParticleBounchyness");
+	PropOffsets_XEmitter.ParticleCollision = cls->GetPropertyDataOffset("ParticleCollision");
+	PropOffsets_XEmitter.ParticleColor = cls->GetPropertyDataOffset("ParticleColor");
+	PropOffsets_XEmitter.ParticleColorScale = cls->GetPropertyDataOffset("ParticleColorScale");
+	PropOffsets_XEmitter.ParticleExtent = cls->GetPropertyDataOffset("ParticleExtent");
+	PropOffsets_XEmitter.ParticleKillCClass = cls->GetPropertyDataOffset("ParticleKillCClass");
+	PropOffsets_XEmitter.ParticleKillTag = cls->GetPropertyDataOffset("ParticleKillTag");
+	PropOffsets_XEmitter.ParticleLifeTimeCClass = cls->GetPropertyDataOffset("ParticleLifeTimeCClass");
+	PropOffsets_XEmitter.ParticleLifeTimeSDelay = cls->GetPropertyDataOffset("ParticleLifeTimeSDelay");
+	PropOffsets_XEmitter.ParticleSpawnCClass = cls->GetPropertyDataOffset("ParticleSpawnCClass");
+	PropOffsets_XEmitter.ParticleSpawnTag = cls->GetPropertyDataOffset("ParticleSpawnTag");
+	PropOffsets_XEmitter.ParticlesPerSec = cls->GetPropertyDataOffset("ParticlesPerSec");
+	PropOffsets_XEmitter.ParticleStyle = cls->GetPropertyDataOffset("ParticleStyle");
+	PropOffsets_XEmitter.ParticleTexCount = cls->GetPropertyDataOffset("ParticleTexCount");
+	PropOffsets_XEmitter.ParticleTextures = cls->GetPropertyDataOffset("ParticleTextures");
+	PropOffsets_XEmitter.ParticleWallHitCClass = cls->GetPropertyDataOffset("ParticleWallHitCClass");
+	PropOffsets_XEmitter.ParticleWallHitTag = cls->GetPropertyDataOffset("ParticleWallHitTag");
+	PropOffsets_XEmitter.PartSpriteForwardZ = cls->GetPropertyDataOffset("PartSpriteForwardZ");
+	PropOffsets_XEmitter.RendBoundingBox = cls->GetPropertyDataOffset("RendBoundingBox");
+	PropOffsets_XEmitter.ResetTimer = cls->GetPropertyDataOffset("ResetTimer");
+	PropOffsets_XEmitter.RevolutionOffset = cls->GetPropertyDataOffset("RevolutionOffset");
+	PropOffsets_XEmitter.RevolutionOffsetUnAxis = cls->GetPropertyDataOffset("RevolutionOffsetUnAxis");
+	PropOffsets_XEmitter.RevolutionsPerSec = cls->GetPropertyDataOffset("RevolutionsPerSec");
+	PropOffsets_XEmitter.RevolutionTimeScale = cls->GetPropertyDataOffset("RevolutionTimeScale");
+	PropOffsets_XEmitter.Scale3DRange = cls->GetPropertyDataOffset("Scale3DRange");
+	PropOffsets_XEmitter.SingleIVert = cls->GetPropertyDataOffset("SingleIVert");
+	PropOffsets_XEmitter.SpawnCombiners = cls->GetPropertyDataOffset("SpawnCombiners");
+	PropOffsets_XEmitter.SpawnInterval = cls->GetPropertyDataOffset("SpawnInterval");
+	PropOffsets_XEmitter.SpawnOffsetMultiplier = cls->GetPropertyDataOffset("SpawnOffsetMultiplier");
+	PropOffsets_XEmitter.SpawnParts = cls->GetPropertyDataOffset("SpawnParts");
+	PropOffsets_XEmitter.SpawnPosType = cls->GetPropertyDataOffset("SpawnPosType");
+	PropOffsets_XEmitter.SpawnSound = cls->GetPropertyDataOffset("SpawnSound");
+	PropOffsets_XEmitter.SpawnVelType = cls->GetPropertyDataOffset("SpawnVelType");
+	PropOffsets_XEmitter.SpeedScale = cls->GetPropertyDataOffset("SpeedScale");
+	PropOffsets_XEmitter.SpeedScaleCount = cls->GetPropertyDataOffset("SpeedScaleCount");
+	PropOffsets_XEmitter.SpeedTimeScale3D = cls->GetPropertyDataOffset("SpeedTimeScale3D");
+	PropOffsets_XEmitter.SphereCylinderRange = cls->GetPropertyDataOffset("SphereCylinderRange");
+	PropOffsets_XEmitter.SphereCylVelocity = cls->GetPropertyDataOffset("SphereCylVelocity");
+	PropOffsets_XEmitter.SpriteAnimationType = cls->GetPropertyDataOffset("SpriteAnimationType");
+	PropOffsets_XEmitter.StartingScale = cls->GetPropertyDataOffset("StartingScale");
+	PropOffsets_XEmitter.TDestructC = cls->GetPropertyDataOffset("TDestructC");
+	PropOffsets_XEmitter.TimeDrawScale3D = cls->GetPropertyDataOffset("TimeDrawScale3D");
+	PropOffsets_XEmitter.TimeScale = cls->GetPropertyDataOffset("TimeScale");
+	PropOffsets_XEmitter.TLifeTimeC = cls->GetPropertyDataOffset("TLifeTimeC");
+	PropOffsets_XEmitter.TriggerAction = cls->GetPropertyDataOffset("TriggerAction");
+	PropOffsets_XEmitter.TSpawnC = cls->GetPropertyDataOffset("TSpawnC");
+	PropOffsets_XEmitter.TWallHitC = cls->GetPropertyDataOffset("TWallHitC");
+	PropOffsets_XEmitter.UseActorCoords = cls->GetPropertyDataOffset("UseActorCoords");
+	PropOffsets_XEmitter.VelocityLossRate = cls->GetPropertyDataOffset("VelocityLossRate");
+	PropOffsets_XEmitter.VertexLimitBBox = cls->GetPropertyDataOffset("VertexLimitBBox");
+	PropOffsets_XEmitter.VisibilityBox = cls->GetPropertyDataOffset("VisibilityBox");
+	PropOffsets_XEmitter.WallHitCombiners = cls->GetPropertyDataOffset("WallHitCombiners");
+	PropOffsets_XEmitter.WallImpactAction = cls->GetPropertyDataOffset("WallImpactAction");
+	PropOffsets_XEmitter.WaterImpactAction = cls->GetPropertyDataOffset("WaterImpactAction");
+}
+
+PropertyOffsets_XParticleForces PropOffsets_XParticleForces;
+
+void InitPropertyOffsets_XParticleForces(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Emitter")->GetUObject("Class", "XParticleForces"));
+	if (!cls)
+	{
+		memset(&PropOffsets_XParticleForces, 0xff, sizeof(PropOffsets_XParticleForces));
+		return;
+	}
+	PropOffsets_XParticleForces.bEnabled = cls->GetPropertyDataOffset("bEnabled");
+	PropOffsets_XParticleForces.bUseBoxForcePosition = cls->GetPropertyDataOffset("bUseBoxForcePosition");
+	PropOffsets_XParticleForces.EffectingBox = cls->GetPropertyDataOffset("EffectingBox");
+	PropOffsets_XParticleForces.EffectingRadius = cls->GetPropertyDataOffset("EffectingRadius");
+	PropOffsets_XParticleForces.EffectPartLifeTime = cls->GetPropertyDataOffset("EffectPartLifeTime");
+	PropOffsets_XParticleForces.OldTagName = cls->GetPropertyDataOffset("OldTagName");
+}
+
+PropertyOffsets_VelocityForce PropOffsets_VelocityForce;
+
+void InitPropertyOffsets_VelocityForce(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Emitter")->GetUObject("Class", "VelocityForce"));
+	if (!cls)
+	{
+		memset(&PropOffsets_VelocityForce, 0xff, sizeof(PropOffsets_VelocityForce));
+		return;
+	}
+	PropOffsets_VelocityForce.bChangeAcceleration = cls->GetPropertyDataOffset("bChangeAcceleration");
+	PropOffsets_VelocityForce.bInstantChange = cls->GetPropertyDataOffset("bInstantChange");
+	PropOffsets_VelocityForce.VelocityToAdd = cls->GetPropertyDataOffset("VelocityToAdd");
+}
+
+PropertyOffsets_KillParticleForce PropOffsets_KillParticleForce;
+
+void InitPropertyOffsets_KillParticleForce(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Emitter")->GetUObject("Class", "KillParticleForce"));
+	if (!cls)
+	{
+		memset(&PropOffsets_KillParticleForce, 0xff, sizeof(PropOffsets_KillParticleForce));
+		return;
+	}
+	PropOffsets_KillParticleForce.LifeTimeDrainAmount = cls->GetPropertyDataOffset("LifeTimeDrainAmount");
+}
+
+PropertyOffsets_ParticleConcentrateForce PropOffsets_ParticleConcentrateForce;
+
+void InitPropertyOffsets_ParticleConcentrateForce(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Emitter")->GetUObject("Class", "ParticleConcentrateForce"));
+	if (!cls)
+	{
+		memset(&PropOffsets_ParticleConcentrateForce, 0xff, sizeof(PropOffsets_ParticleConcentrateForce));
+		return;
+	}
+	PropOffsets_ParticleConcentrateForce.bActorDistanceSuckIn = cls->GetPropertyDataOffset("bActorDistanceSuckIn");
+	PropOffsets_ParticleConcentrateForce.bSetsAcceleration = cls->GetPropertyDataOffset("bSetsAcceleration");
+	PropOffsets_ParticleConcentrateForce.CenterPointOffset = cls->GetPropertyDataOffset("CenterPointOffset");
+	PropOffsets_ParticleConcentrateForce.DrainSpeed = cls->GetPropertyDataOffset("DrainSpeed");
+	PropOffsets_ParticleConcentrateForce.MaxDistance = cls->GetPropertyDataOffset("MaxDistance");
+}
+
+PropertyOffsets_XBeamEmitter PropOffsets_XBeamEmitter;
+
+void InitPropertyOffsets_XBeamEmitter(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Emitter")->GetUObject("Class", "XBeamEmitter"));
+	if (!cls)
+	{
+		memset(&PropOffsets_XBeamEmitter, 0xff, sizeof(PropOffsets_XBeamEmitter));
+		return;
+	}
+	PropOffsets_XBeamEmitter.bDoBeamNoise = cls->GetPropertyDataOffset("bDoBeamNoise");
+	PropOffsets_XBeamEmitter.bDynamicNoise = cls->GetPropertyDataOffset("bDynamicNoise");
+	PropOffsets_XBeamEmitter.BeamPointScaling = cls->GetPropertyDataOffset("BeamPointScaling");
+	PropOffsets_XBeamEmitter.BeamTarget = cls->GetPropertyDataOffset("BeamTarget");
+	PropOffsets_XBeamEmitter.EndTexture = cls->GetPropertyDataOffset("EndTexture");
+	PropOffsets_XBeamEmitter.NoiseRange = cls->GetPropertyDataOffset("NoiseRange");
+	PropOffsets_XBeamEmitter.NoiseSwapTime = cls->GetPropertyDataOffset("NoiseSwapTime");
+	PropOffsets_XBeamEmitter.NoiseTimeScale = cls->GetPropertyDataOffset("NoiseTimeScale");
+	PropOffsets_XBeamEmitter.RenderDataModel = cls->GetPropertyDataOffset("RenderDataModel");
+	PropOffsets_XBeamEmitter.Segments = cls->GetPropertyDataOffset("Segments");
+	PropOffsets_XBeamEmitter.SegmentScales = cls->GetPropertyDataOffset("SegmentScales");
+	PropOffsets_XBeamEmitter.StartTexture = cls->GetPropertyDataOffset("StartTexture");
+	PropOffsets_XBeamEmitter.TextureUV = cls->GetPropertyDataOffset("TextureUV");
+	PropOffsets_XBeamEmitter.TurnRate = cls->GetPropertyDataOffset("TurnRate");
+}
+
 //////////////////////////////////////////
 
 void InitPropertyOffsets(PackageManager* packages)
@@ -4830,6 +5073,16 @@ void InitPropertyOffsets(PackageManager* packages)
 	{
 		InitPropertyOffsets_UPakPathNodeIterator(packages);
 		InitPropertyOffsets_UPakPawnPathNodeIterator(packages);
+	}
+	if (packages->IsUnreal1_227())
+	{
+		InitPropertyOffsets_XParticleEmitter(packages);
+		InitPropertyOffsets_XParticleForces(packages);
+		InitPropertyOffsets_VelocityForce(packages);
+		InitPropertyOffsets_KillParticleForce(packages);
+		InitPropertyOffsets_ParticleConcentrateForce(packages);
+		InitPropertyOffsets_XEmitter(packages);
+		InitPropertyOffsets_XBeamEmitter(packages);
 	}
 	if (packages->IsDeusEx())
 	{

--- a/SurrealEngine/UObject/PropertyOffsets.cpp
+++ b/SurrealEngine/UObject/PropertyOffsets.cpp
@@ -18,11 +18,11 @@ static void InitPropertyOffsets_Object(PackageManager* packages)
 	PropOffsets_Object.Class = cls->GetPropertyDataOffset("Class");
 	PropOffsets_Object.Name = cls->GetPropertyDataOffset("Name");
 	PropOffsets_Object.ObjectFlags = cls->GetPropertyDataOffset("ObjectFlags");
-	if (!packages->IsUnreal1_227())
+	if (!packages->IsUnreal1_227k())
 		PropOffsets_Object.ObjectInternal = cls->GetPropertyDataOffset("ObjectInternal");
 	PropOffsets_Object.Outer = cls->GetPropertyDataOffset("Outer");
 
-	if (packages->IsUnreal1_227())
+	if (packages->IsUnreal1_227k()) // These got added on 227k (or maybe j?)
 	{
 		PropOffsets_Object.ObjectIndex = cls->GetPropertyDataOffset("ObjectIndex");
 		PropOffsets_Object.ObjectArchetype = cls->GetPropertyDataOffset("ObjectArchetype");

--- a/SurrealEngine/UObject/PropertyOffsets.h
+++ b/SurrealEngine/UObject/PropertyOffsets.h
@@ -3778,3 +3778,204 @@ struct PropertyOffsets_TabGroupWindow
 extern PropertyOffsets_TabGroupWindow PropOffsets_TabGroupWindow;
 
 /////////////////////////////////////////////////////////////////////////////
+
+struct PropertyOffsets_XParticleEmitter
+{
+	PropertyDataOffset ActiveCount;
+	PropertyDataOffset bHasInitilized; // sic
+	PropertyDataOffset bKillNextTick;
+	PropertyDataOffset bHasSpecialParts;
+	PropertyDataOffset bWasPostDestroyed;
+	PropertyDataOffset bHasInitView;
+	PropertyDataOffset PartCombiners;
+	PropertyDataOffset bUSNotifyParticles;
+	PropertyDataOffset bNotifyNetReceive;
+	PropertyDataOffset bUSModifyParticles;
+	PropertyDataOffset bNotOnPortals;
+};
+
+extern PropertyOffsets_XParticleEmitter PropOffsets_XParticleEmitter;
+
+struct PropertyOffsets_XEmitter
+{
+	PropertyDataOffset NextParticleTime;
+	PropertyDataOffset SpawnInterval;
+	PropertyDataOffset ResetTimer;
+	PropertyDataOffset SpeedScaleCount;
+	PropertyDataOffset DrawScaleCount;
+	PropertyDataOffset ParticleTexCount;
+	PropertyDataOffset ColorScaleCount;
+	PropertyDataOffset CacheRot;
+	PropertyDataOffset OldSpawnPosition;
+	PropertyDataOffset RendBoundingBox;
+	PropertyDataOffset SpawnCombiners;
+	PropertyDataOffset LifeTimeCombiners;
+	PropertyDataOffset DestructCombiners;
+	PropertyDataOffset WallHitCombiners;
+	PropertyDataOffset TSpawnC;
+	PropertyDataOffset TLifeTimeC;
+	PropertyDataOffset TDestructC;
+	PropertyDataOffset TWallHitC;
+	PropertyDataOffset MaxParticles;
+	PropertyDataOffset ParticlesPerSec;
+	PropertyDataOffset LODFactor;
+	PropertyDataOffset LifetimeRange;
+	PropertyDataOffset AutoResetTime;
+	PropertyDataOffset FinishedSpawningTrigger;
+	PropertyDataOffset RevolutionOffset;
+	PropertyDataOffset RevolutionsPerSec;
+	PropertyDataOffset RevolutionTimeScale;
+	PropertyDataOffset RevolutionOffsetUnAxis;
+	PropertyDataOffset ParticleTextures;
+	PropertyDataOffset ParticleStyle;
+	PropertyDataOffset ParticleSpawnTag;
+	PropertyDataOffset ParticleSpawnCClass;
+	PropertyDataOffset ParticleKillTag;
+	PropertyDataOffset ParticleKillCClass;
+	PropertyDataOffset ParticleWallHitTag;
+	PropertyDataOffset ParticleWallHitCClass;
+	PropertyDataOffset CombinedParticleCount;
+	PropertyDataOffset ParticleLifeTimeCClass;
+	PropertyDataOffset ParticleLifeTimeSDelay;
+	PropertyDataOffset FadeInTime;
+	PropertyDataOffset FadeOutTime;
+	PropertyDataOffset FadeInMaxAmount;
+	PropertyDataOffset StartingScale;
+	PropertyDataOffset Scale3DRange;
+	PropertyDataOffset TimeScale;
+	PropertyDataOffset TimeDrawScale3D;
+	PropertyDataOffset SpriteAnimationType;
+	PropertyDataOffset PartSpriteForwardZ;
+	PropertyDataOffset VisibilityBox;
+	PropertyDataOffset CullDistance;
+	PropertyDataOffset CullDistanceFadeDist;
+	PropertyDataOffset BoxLocation;
+	PropertyDataOffset SphereCylinderRange;
+	PropertyDataOffset SpawnPosType;
+	PropertyDataOffset SpawnOffsetMultiplier;
+	PropertyDataOffset UseActorCoords;
+	PropertyDataOffset VertexLimitBBox;
+	PropertyDataOffset SingleIVert;
+	PropertyDataOffset TriggerAction;
+	PropertyDataOffset SpawnParts;
+	PropertyDataOffset SpeedScale;
+	PropertyDataOffset ParticleAcceleration;
+	PropertyDataOffset BoxVelocity;
+	PropertyDataOffset SphereCylVelocity;
+	PropertyDataOffset SpawnVelType;
+	PropertyDataOffset VelocityLossRate;
+	PropertyDataOffset SpeedTimeScale3D;
+	PropertyDataOffset ParticleCollision;
+	PropertyDataOffset WallImpactAction;
+	PropertyDataOffset WaterImpactAction;
+	PropertyDataOffset ParticleExtent;
+	PropertyDataOffset ParticleBounchyness; // Sic
+	PropertyDataOffset HittingActorKickVelScale;
+	PropertyDataOffset MinBounceVelocity;
+	PropertyDataOffset ImpactSound;
+	PropertyDataOffset SpawnSound;
+	PropertyDataOffset DestroySound;
+	PropertyDataOffset MinImpactVelForSnd;
+	PropertyDataOffset ForcesList;
+	PropertyDataOffset ForcesTags;
+	PropertyDataOffset ParticleColor;
+	PropertyDataOffset ParticleColorScale;
+	PropertyDataOffset CoronaColor;
+	PropertyDataOffset CoronaTexture;
+	PropertyDataOffset CoronaFadeTimeScale;
+	PropertyDataOffset CoronaMaxScale;
+	PropertyDataOffset CoronaScaling;
+	PropertyDataOffset MaxCoronaDistance;
+	PropertyDataOffset CoronaOffset;
+	PropertyDataOffset bRevolutionEnabled;
+	PropertyDataOffset bEffectsVelocity;
+	PropertyDataOffset bDisabled; // For the emitter as a whole
+	PropertyDataOffset bRespawnParticles;
+	PropertyDataOffset bAutoDestroy;
+	PropertyDataOffset bAutoReset;
+	PropertyDataOffset bSpawnInitParticles;
+	PropertyDataOffset bDisableRender;
+	PropertyDataOffset bUseRandomTex;
+	PropertyDataOffset bBoxVisibility;
+	PropertyDataOffset bAutoVisibilityBox;
+	PropertyDataOffset bDistanceCulling;
+	PropertyDataOffset bStatisEmitter;
+	PropertyDataOffset bNoUpdateOnInvis;
+	PropertyDataOffset bRelativeToRotation;
+	PropertyDataOffset bUseRelativeLocation;
+	PropertyDataOffset bGradualSpawnCoords;
+	PropertyDataOffset bUseMeshAnim;
+	PropertyDataOffset bVelRelativeToRotation;
+	PropertyDataOffset bCylRangeBasedOnPos;
+	PropertyDataOffset bAccelRelativeToRot;
+	PropertyDataOffset bCheckLineOfSight;
+	PropertyDataOffset bActorsBlockSight;
+	PropertyDataOffset bParticleCoronaEnabled;
+	PropertyDataOffset bCOffsetRelativeToRot;
+	PropertyDataOffset bHasLossVel;
+	PropertyDataOffset bHasAliveParticles;
+	PropertyDataOffset bDestruction;
+	PropertyDataOffset bRotationRequest;
+	PropertyDataOffset BACKUP_Disabled;
+};
+
+extern PropertyOffsets_XEmitter PropOffsets_XEmitter;
+
+struct PropertyOffsets_XParticleForces
+{
+	PropertyDataOffset EffectingRadius;
+	PropertyDataOffset EffectingBox;
+	PropertyDataOffset EffectPartLifeTime;
+	PropertyDataOffset OldTagName;
+	PropertyDataOffset bEnabled;
+	PropertyDataOffset bUseBoxForcePosition;
+};
+
+extern PropertyOffsets_XParticleForces PropOffsets_XParticleForces;
+
+struct PropertyOffsets_VelocityForce
+{
+	PropertyDataOffset VelocityToAdd;
+	PropertyDataOffset bChangeAcceleration;
+	PropertyDataOffset bInstantChange;
+};
+
+extern PropertyOffsets_VelocityForce PropOffsets_VelocityForce;
+
+struct PropertyOffsets_KillParticleForce
+{
+	PropertyDataOffset LifeTimeDrainAmount;
+};
+
+extern PropertyOffsets_KillParticleForce PropOffsets_KillParticleForce;
+
+struct PropertyOffsets_ParticleConcentrateForce
+{
+	PropertyDataOffset CenterPointOffset;
+	PropertyDataOffset DrainSpeed;
+	PropertyDataOffset bSetsAcceleration;
+	PropertyDataOffset bActorDistanceSuckIn;
+	PropertyDataOffset MaxDistance;
+};
+
+extern PropertyOffsets_ParticleConcentrateForce PropOffsets_ParticleConcentrateForce;
+
+struct PropertyOffsets_XBeamEmitter
+{
+	PropertyDataOffset BeamTarget;
+	PropertyDataOffset NoiseTimeScale;
+	PropertyDataOffset NoiseSwapTime;
+	PropertyDataOffset Segments;
+	PropertyDataOffset TextureUV;
+	PropertyDataOffset NoiseRange;
+	PropertyDataOffset TurnRate;
+	PropertyDataOffset BeamPointScaling;
+	PropertyDataOffset StartTexture;
+	PropertyDataOffset EndTexture;
+	PropertyDataOffset RenderDataModel;
+	PropertyDataOffset SegmentScales;
+	PropertyDataOffset bDynamicNoise;
+	PropertyDataOffset bDoBeamNoise;
+};
+
+extern PropertyOffsets_XBeamEmitter PropOffsets_XBeamEmitter;

--- a/SurrealEngine/UObject/PropertyOffsets.h
+++ b/SurrealEngine/UObject/PropertyOffsets.h
@@ -17,7 +17,7 @@ struct PropertyOffsets_Object
 	PropertyDataOffset ObjectFlags;
 	PropertyDataOffset ObjectInternal;
 	PropertyDataOffset Outer;
-	// 227 additions
+	// 227k additions
 	PropertyDataOffset ObjectIndex;
 	PropertyDataOffset ObjectArchetype;
 };

--- a/SurrealEngine/UObject/U227Emitter.cpp
+++ b/SurrealEngine/UObject/U227Emitter.cpp
@@ -1,0 +1,8 @@
+#include "U227Emitter.h"
+
+#include "Utils/Logger.h"
+
+void UXParticleEmitter::SetParticlesProps(std::optional<float> Speed, std::optional<float> Scale)
+{
+    LogUnimplemented("XParticleEmitter.SetParticlesProps() [U227]");
+}

--- a/SurrealEngine/UObject/U227Emitter.h
+++ b/SurrealEngine/UObject/U227Emitter.h
@@ -1,0 +1,361 @@
+#pragma once
+
+#include "U227Emitter.h"
+#include "UActor.h"
+
+class UXEmitter;
+class UXParticleForces;
+
+// Structs found in XParticleEmitter
+// These are used in subclasses
+
+struct IntRange
+{
+    int Min, Max;
+};
+
+struct ByteRange
+{
+    uint8_t Min, Max;
+};
+
+struct FloatRange
+{
+    float Min, Max;
+};
+
+struct RangeVector
+{
+    FloatRange X, Y, Z;
+};
+
+struct ParticleSndType
+{
+    USound* Sounds[8];
+    FloatRange SndPitch, SndRadius, SndVolume;
+    uint8_t SndCount;
+};
+
+// Enums found in XParticleEmitter
+
+enum class EHitEventType : uint8_t
+{
+    HIT_DoNothing,
+    HIT_Destroy,
+    HIT_StopMovement,
+    HIT_Bounce,
+    HIT_Script
+};
+
+// Particle Emitter base class
+class UXParticleEmitter : public UActor
+{
+public:
+    using UActor::UActor;
+
+    int& ActiveCount() { return Value<int>(PropOffsets_XParticleEmitter.ActiveCount); }
+    BitfieldBool bHasInitilized() { return BoolValue(PropOffsets_XParticleEmitter.bHasInitilized); }
+    BitfieldBool bKillNextTick() { return BoolValue(PropOffsets_XParticleEmitter.bKillNextTick); }
+    BitfieldBool bHasSpecialParts() { return BoolValue(PropOffsets_XParticleEmitter.bHasSpecialParts); }
+    BitfieldBool bWasPostDestroyed() { return BoolValue(PropOffsets_XParticleEmitter.bWasPostDestroyed); }
+    BitfieldBool bHasInitView() { return BoolValue(PropOffsets_XParticleEmitter.bHasInitView); }
+    Array<UXEmitter*> PartCombiners() { return DynamicArray<UXEmitter*>(PropOffsets_XParticleEmitter.PartCombiners); }
+    BitfieldBool bUSNotifyParticles() { return BoolValue(PropOffsets_XParticleEmitter.bUSNotifyParticles); }
+    BitfieldBool bNotifyNetReceive() { return BoolValue(PropOffsets_XParticleEmitter.bNotifyNetReceive); }
+    BitfieldBool bUSModifyParticles() { return BoolValue(PropOffsets_XParticleEmitter.bUSModifyParticles); }
+    BitfieldBool bNotOnPortals() { return BoolValue(PropOffsets_XParticleEmitter.bNotOnPortals); }
+
+    void SetParticlesProps(std::optional<float> Speed, std::optional<float> Scale);
+};
+
+// Enums found in XEmitter
+
+enum class ESpawnPosType : uint8_t
+{
+    SP_Box,
+    SP_Sphere,
+    SP_Cylinder,
+    SP_BoxSphere,
+    SP_BoxCylinder
+};
+
+enum class EEmitterTriggerType : uint8_t
+{
+    ETR_ToggleDisabled,
+    ETR_ResetEmitter,
+    ETR_SpawnParticles
+};
+
+enum class EEmitterPartCol : uint8_t
+{
+    ECT_HitNothing,
+    ECT_HitWalls,
+    ECT_HitActors,
+    ECT_HitProjTargets
+};
+
+enum class ESpriteAnimType : uint8_t
+{
+    SAN_None,
+    SAN_PlayOnce,
+    SAN_PlayOnceInverted,
+    SAN_LoopAnim
+};
+
+// Structs found in XEmitter
+
+struct SpeedRangeType
+{
+    float VelocityScale, Time;
+};
+
+struct Speed3DType
+{
+    vec3 VelocityScale;
+    float Time;
+};
+
+struct RevolveScaleType
+{
+    vec3 RevolutionScale;
+    float Time;
+};
+
+struct ScaleRangeType
+{
+    float DrawScaling, Type;
+};
+
+struct ColorScaleRangeType
+{
+    float Time;
+    vec3 ColorScaling;
+};
+
+struct Box
+{
+    vec3 Min, Max;
+    uint8_t IsValid; // No idea why this is a byte instead of a bool
+};
+
+// Enums found in XBeamEmitter
+
+enum class EBeamTargetType : uint8_t
+{
+    BEAM_Velocity,
+    BEAM_BeamActor,
+    BEAM_Offset,
+    BEAM_OffsetAsAbsolute
+};
+
+// Structs found in XBeamEmitter
+
+struct FBeamTargetPoint
+{
+    UActor* TargetActor;
+    vec3* Offset;
+};
+
+// Normal Particle Emitter
+class UXEmitter : public UXParticleEmitter
+{
+    using UXParticleEmitter::UXParticleEmitter;
+
+    FloatRange*& AutoResetTime() { return Value<FloatRange*>(PropOffsets_XEmitter.AutoResetTime); }
+    BitfieldBool bAccelRelativeToRot() { return BoolValue(PropOffsets_XEmitter.bAccelRelativeToRot); }
+    BitfieldBool BACKUP_Disabled() { return BoolValue(PropOffsets_XEmitter.BACKUP_Disabled); }
+    BitfieldBool bActorsBlockSight() { return BoolValue(PropOffsets_XEmitter.bActorsBlockSight); }
+    BitfieldBool bAutoDestroy() { return BoolValue(PropOffsets_XEmitter.bAutoDestroy); }
+    BitfieldBool bAutoReset() { return BoolValue(PropOffsets_XEmitter.bAutoReset); }
+    BitfieldBool bAutoVisibilityBox() { return BoolValue(PropOffsets_XEmitter.bAutoVisibilityBox); }
+    BitfieldBool bBoxVisibility() { return BoolValue(PropOffsets_XEmitter.bBoxVisibility); }
+    BitfieldBool bCheckLineOfSight() { return BoolValue(PropOffsets_XEmitter.bCheckLineOfSight); }
+    BitfieldBool bCOffsetRelativeToRot() { return BoolValue(PropOffsets_XEmitter.bCOffsetRelativeToRot); }
+    BitfieldBool bCylRangeBasedOnPos() { return BoolValue(PropOffsets_XEmitter.bCylRangeBasedOnPos); }
+    BitfieldBool bDestruction() { return BoolValue(PropOffsets_XEmitter.bDestruction); }
+    BitfieldBool bDisabled() { return BoolValue(PropOffsets_XEmitter.bDisabled); }
+    BitfieldBool bDisableRender() { return BoolValue(PropOffsets_XEmitter.bDisableRender); }
+    BitfieldBool bDistanceCulling() { return BoolValue(PropOffsets_XEmitter.bDistanceCulling); }
+    BitfieldBool bEffectsVelocity() { return BoolValue(PropOffsets_XEmitter.bEffectsVelocity); }
+    BitfieldBool bGradualSpawnCoords() { return BoolValue(PropOffsets_XEmitter.bGradualSpawnCoords); }
+    BitfieldBool bHasAliveParticles() { return BoolValue(PropOffsets_XEmitter.bHasAliveParticles); }
+    BitfieldBool bHasLossVel() { return BoolValue(PropOffsets_XEmitter.bHasLossVel); }
+    BitfieldBool bNoUpdateOnInvis() { return BoolValue(PropOffsets_XEmitter.bNoUpdateOnInvis); }
+    BitfieldBool bParticleCoronaEnabled() { return BoolValue(PropOffsets_XEmitter.bParticleCoronaEnabled); }
+    BitfieldBool bRelativeToRotation() { return BoolValue(PropOffsets_XEmitter.bRelativeToRotation); }
+    BitfieldBool bRespawnParticles() { return BoolValue(PropOffsets_XEmitter.bRespawnParticles); }
+    BitfieldBool bRevolutionEnabled() { return BoolValue(PropOffsets_XEmitter.bRevolutionEnabled); }
+    BitfieldBool bRotationRequest() { return BoolValue(PropOffsets_XEmitter.bRotationRequest); }
+    BitfieldBool bSpawnInitParticles() { return BoolValue(PropOffsets_XEmitter.bSpawnInitParticles); }
+    BitfieldBool bStatisEmitter() { return BoolValue(PropOffsets_XEmitter.bStatisEmitter); }
+    BitfieldBool bUseMeshAnim() { return BoolValue(PropOffsets_XEmitter.bUseMeshAnim); }
+    BitfieldBool bUseRandomTex() { return BoolValue(PropOffsets_XEmitter.bUseRandomTex); }
+    BitfieldBool bUseRelativeLocation() { return BoolValue(PropOffsets_XEmitter.bUseRelativeLocation); }
+    BitfieldBool bVelRelativeToRotation() { return BoolValue(PropOffsets_XEmitter.bVelRelativeToRotation); }
+    RangeVector*& BoxLocation() { return Value<RangeVector*>(PropOffsets_XEmitter.BoxLocation); }
+    RangeVector*& BoxVelocity() { return Value<RangeVector*>(PropOffsets_XEmitter.BoxVelocity); }
+    Coords& CacheRot() { return Value<Coords>(PropOffsets_XEmitter.CacheRot); }
+    uint8_t& ColorScaleCount() { return Value<uint8_t>(PropOffsets_XEmitter.ColorScaleCount); }
+    IntRange*& CombinedParticleCount() { return Value<IntRange*>(PropOffsets_XEmitter.CombinedParticleCount); }
+    RangeVector*& CoronaColor() { return Value<RangeVector*>(PropOffsets_XEmitter.CoronaColor); }
+    float& CoronaFadeTimeScale() { return Value<float>(PropOffsets_XEmitter.CoronaFadeTimeScale); }
+    float& CoronaMaxScale() { return Value<float>(PropOffsets_XEmitter.CoronaMaxScale); }
+    vec3*& CoronaOffset() { return Value<vec3*>(PropOffsets_XEmitter.CoronaOffset); }
+    float& CoronaScaling() { return Value<float>(PropOffsets_XEmitter.CoronaScaling); }
+    UTexture*& CoronaTexture() { return Value<UTexture*>(PropOffsets_XEmitter.CoronaTexture); }
+    float& CullDistance() { return Value<float>(PropOffsets_XEmitter.CullDistance); }
+    float& CullDistanceFadeDist() { return Value<float>(PropOffsets_XEmitter.CullDistanceFadeDist); }
+    ParticleSndType*& DestroySound() { return Value<ParticleSndType*>(PropOffsets_XEmitter.DestroySound); }
+    Array<UXEmitter*> DestructCombiners() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.DestructCombiners); }
+    uint8_t& DrawScaleCount() { return Value<uint8_t>(PropOffsets_XEmitter.DrawScaleCount); }
+    float& FadeInMaxAmount() { return Value<float>(PropOffsets_XEmitter.FadeInMaxAmount); }
+    float& FadeInTime() { return Value<float>(PropOffsets_XEmitter.FadeInTime); }
+    float& FadeOutTime() { return Value<float>(PropOffsets_XEmitter.FadeOutTime); }
+    UActor*& FinishedSpawningTrigger() { return Value<UActor*>(PropOffsets_XEmitter.FinishedSpawningTrigger); }
+    Array<UXParticleForces*> ForcesList() { return DynamicArray<UXParticleForces*>(PropOffsets_XEmitter.ForcesList); }
+    FixedArrayView<NameString, 4> ForcesTags() { return FixedArray<NameString, 4>(PropOffsets_XEmitter.ForcesTags); }
+    float& HittingActorKickVelScale() { return Value<float>(PropOffsets_XEmitter.HittingActorKickVelScale); }
+    ParticleSndType*& ImpactSound() { return Value<ParticleSndType*>(PropOffsets_XEmitter.ImpactSound); }
+    Array<UXEmitter*> LifeTimeCombiners() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.LifeTimeCombiners); }
+    FloatRange*& LifetimeRange() { return Value<FloatRange*>(PropOffsets_XEmitter.LifetimeRange); }
+    float& LODFactor() { return Value<float>(PropOffsets_XEmitter.LODFactor); }
+    float& MaxCoronaDistance() { return Value<float>(PropOffsets_XEmitter.MaxCoronaDistance); }
+    int& MaxParticles() { return Value<int>(PropOffsets_XEmitter.MaxParticles); }
+    float& MinBounceVelocity() { return Value<float>(PropOffsets_XEmitter.MinBounceVelocity); }
+    float& MinImpactVelForSnd() { return Value<float>(PropOffsets_XEmitter.MinImpactVelForSnd); }
+    float& NextParticleTime() { return Value<float>(PropOffsets_XEmitter.NextParticleTime); }
+    vec3*& OldSpawnPosition() { return Value<vec3*>(PropOffsets_XEmitter.OldSpawnPosition); }
+    RangeVector*& ParticleAcceleration() { return Value<RangeVector*>(PropOffsets_XEmitter.ParticleAcceleration); }
+    vec3*& ParticleBounchyness() { return Value<vec3*>(PropOffsets_XEmitter.ParticleBounchyness); }
+    EEmitterPartCol ParticleCollision() { return static_cast<EEmitterPartCol>(Value<uint8_t>(PropOffsets_XEmitter.ParticleCollision)); }
+    RangeVector*& ParticleColor() { return Value<RangeVector*>(PropOffsets_XEmitter.ParticleColor); }
+    FixedArrayView<ColorScaleRangeType*, 5> ParticleColorScale() { return FixedArray<ColorScaleRangeType*, 5>(PropOffsets_XEmitter.ParticleColorScale); }
+    vec3*& ParticleExtent() { return Value<vec3*>(PropOffsets_XEmitter.ParticleExtent); }
+    Array<UClass*> ParticleKillCClass() { return DynamicArray<UClass*>(PropOffsets_XEmitter.ParticleKillCClass); }
+    NameString& ParticleKillTag() { return Value<NameString>(PropOffsets_XEmitter.ParticleKillTag); }
+    Array<UClass*> ParticleLifeTimeCClass() { return DynamicArray<UClass*>(PropOffsets_XEmitter.ParticleLifeTimeCClass); }
+    FloatRange*& ParticleLifeTimeSDelay() { return Value<FloatRange*>(PropOffsets_XEmitter.ParticleLifeTimeSDelay); }
+    Array<UClass*> ParticleSpawnCClass() { return DynamicArray<UClass*>(PropOffsets_XEmitter.ParticleSpawnCClass); }
+    NameString& ParticleSpawnTag() { return Value<NameString>(PropOffsets_XEmitter.ParticleSpawnTag); }
+    float& ParticlesPerSec() { return Value<float>(PropOffsets_XEmitter.ParticlesPerSec); }
+    uint8_t& ParticleStyle() { return Value<uint8_t>(PropOffsets_XEmitter.ParticleStyle); } // ERenderStyle
+    uint8_t& ParticleTexCount() { return Value<uint8_t>(PropOffsets_XEmitter.ParticleTexCount); }
+    FixedArrayView<UTexture*, 16> ParticleTextures() { return FixedArray<UTexture*, 16>(PropOffsets_XEmitter.ParticleTextures); }
+    Array<UClass*> ParticleWallHitCClass() { return DynamicArray<UClass*>(PropOffsets_XEmitter.ParticleWallHitCClass); }
+    NameString& ParticleWallHitTag() { return Value<NameString>(PropOffsets_XEmitter.ParticleWallHitTag); }
+    float& PartSpriteForwardZ() { return Value<float>(PropOffsets_XEmitter.PartSpriteForwardZ); }
+    Box*& RendBoundingBox() { return Value<Box*>(PropOffsets_XEmitter.RendBoundingBox); }
+    float& ResetTimer() { return Value<float>(PropOffsets_XEmitter.ResetTimer); }
+    RangeVector*& RevolutionOffset() { return Value<RangeVector*>(PropOffsets_XEmitter.RevolutionOffset); }
+    vec3*& RevolutionOffsetUnAxis() { return Value<vec3*>(PropOffsets_XEmitter.RevolutionOffsetUnAxis); }
+    RangeVector*& RevolutionsPerSec() { return Value<RangeVector*>(PropOffsets_XEmitter.RevolutionsPerSec); }
+    Array<RevolveScaleType*> RevolutionTimeScale() { return DynamicArray<RevolveScaleType*>(PropOffsets_XEmitter.RevolutionTimeScale); }
+    RangeVector*& Scale3DRange() { return Value<RangeVector*>(PropOffsets_XEmitter.Scale3DRange); }
+    int& SingleIVert() { return Value<int>(PropOffsets_XEmitter.SingleIVert); }
+    Array<UXEmitter*> SpawnCombiners() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.SpawnCombiners); }
+    float& SpawnInterval() { return Value<float>(PropOffsets_XEmitter.SpawnInterval); }
+    vec3*& SpawnOffsetMultiplier() { return Value<vec3*>(PropOffsets_XEmitter.SpawnOffsetMultiplier); }
+    IntRange*& SpawnParts() { return Value<IntRange*>(PropOffsets_XEmitter.SpawnParts); }
+    ESpawnPosType SpawnPosType() { return static_cast<ESpawnPosType>(Value<uint8_t>(PropOffsets_XEmitter.SpawnPosType)); }
+    ParticleSndType*& SpawnSound() { return Value<ParticleSndType*>(PropOffsets_XEmitter.SpawnSound); }
+    ESpawnPosType SpawnVelType() { return static_cast<ESpawnPosType>(Value<uint8_t>(PropOffsets_XEmitter.SpawnVelType)); }
+    FixedArrayView<SpeedRangeType*, 5> SpeedScale() { return FixedArray<SpeedRangeType*, 5>(PropOffsets_XEmitter.SpeedScale); }
+    uint8_t& SpeedScaleCount() { return Value<uint8_t>(PropOffsets_XEmitter.SpeedScaleCount); }
+    Array<Speed3DType*> SpeedTimeScale3D() { return DynamicArray<Speed3DType*>(PropOffsets_XEmitter.SpeedTimeScale3D); }
+    FloatRange*& SphereCylinderRange() { return Value<FloatRange*>(PropOffsets_XEmitter.SphereCylinderRange); }
+    FloatRange*& SphereCylVelocity() { return Value<FloatRange*>(PropOffsets_XEmitter.SphereCylVelocity); }
+    ESpriteAnimType SpriteAnimationType() { return static_cast<ESpriteAnimType>(Value<uint8_t>(PropOffsets_XEmitter.SpriteAnimationType)); }
+    FloatRange*& StartingScale() { return Value<FloatRange*>(PropOffsets_XEmitter.StartingScale); }
+    Array<UXEmitter*> TDestructC() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.TDestructC); }
+    Array<Speed3DType*> TimeDrawScale3D() { return DynamicArray<Speed3DType*>(PropOffsets_XEmitter.TimeDrawScale3D); }
+    FixedArrayView<ScaleRangeType*, 5> TimeScale() { return FixedArray<ScaleRangeType*, 5>(PropOffsets_XEmitter.TimeScale); }
+    Array<UXEmitter*> TLifeTimeC() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.TLifeTimeC); }
+    EEmitterTriggerType TriggerAction() { return static_cast<EEmitterTriggerType>(Value<uint8_t>(PropOffsets_XEmitter.TriggerAction)); }
+    Array<UXEmitter*> TSpawnC() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.TSpawnC); }
+    Array<UXEmitter*> TWallHitC() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.TWallHitC); }
+    UActor*& UseActorCoords() { return Value<UActor*>(PropOffsets_XEmitter.UseActorCoords); }
+    vec3*& VelocityLossRate() { return Value<vec3*>(PropOffsets_XEmitter.VelocityLossRate); }
+    Box*& VertexLimitBBox() { return Value<Box*>(PropOffsets_XEmitter.VertexLimitBBox); }
+    Box*& VisibilityBox() { return Value<Box*>(PropOffsets_XEmitter.VisibilityBox); }
+    Array<UXEmitter*> WallHitCombiners() { return DynamicArray<UXEmitter*>(PropOffsets_XEmitter.WallHitCombiners); }
+    EHitEventType WallImpactAction() { return static_cast<EHitEventType>(Value<uint8_t>(PropOffsets_XEmitter.WallImpactAction)); }
+    EHitEventType WaterImpactAction() { return static_cast<EHitEventType>(Value<uint8_t>(PropOffsets_XEmitter.WaterImpactAction)); }
+};
+
+class UXParticleForces : public UActor
+{
+public:
+    using UActor::UActor;
+
+    BitfieldBool bEnabled() { return BoolValue(PropOffsets_XParticleForces.bEnabled); }
+    BitfieldBool bUseBoxForcePosition() { return BoolValue(PropOffsets_XParticleForces.bUseBoxForcePosition); }
+    Box*& EffectingBox() { return Value<Box*>(PropOffsets_XParticleForces.EffectingBox); }
+    float& EffectingRadius() { return Value<float>(PropOffsets_XParticleForces.EffectingRadius); }
+    FloatRange*& EffectPartLifeTime() { return Value<FloatRange*>(PropOffsets_XParticleForces.EffectPartLifeTime); }
+    NameString& OldTagName() { return Value<NameString>(PropOffsets_XParticleForces.OldTagName); }
+};
+
+class UVelocityForce : public UXParticleForces
+{
+public:
+    using UXParticleForces::UXParticleForces;
+
+    BitfieldBool bChangeAcceleration() { return BoolValue(PropOffsets_VelocityForce.bChangeAcceleration); }
+    BitfieldBool bInstantChange() { return BoolValue(PropOffsets_VelocityForce.bInstantChange); }
+    vec3*& VelocityToAdd() { return Value<vec3*>(PropOffsets_VelocityForce.VelocityToAdd); }
+};
+
+class UKillParticleForce : public UXParticleForces
+{
+public:
+    using UXParticleForces::UXParticleForces;
+
+    float& LifeTimeDrainAmount() { return Value<float>(PropOffsets_KillParticleForce.LifeTimeDrainAmount); }
+};
+
+class UParticleConcentrateForce : public UXParticleForces
+{
+public:
+    using UXParticleForces::UXParticleForces;
+
+    BitfieldBool bActorDistanceSuckIn() { return BoolValue(PropOffsets_ParticleConcentrateForce.bActorDistanceSuckIn); }
+    BitfieldBool bSetsAcceleration() { return BoolValue(PropOffsets_ParticleConcentrateForce.bSetsAcceleration); }
+    vec3*& CenterPointOffset() { return Value<vec3*>(PropOffsets_ParticleConcentrateForce.CenterPointOffset); }
+    float& DrainSpeed() { return Value<float>(PropOffsets_ParticleConcentrateForce.DrainSpeed); }
+    float& MaxDistance() { return Value<float>(PropOffsets_ParticleConcentrateForce.MaxDistance); }
+};
+
+// A resource class for particles to use
+class UEmitterRC : public UActor
+{
+public:
+    using UActor::UActor;
+};
+
+// A pretty much empty class that gets immediately destroyed on PreBeginPlay()
+class UXTrailParticle : public UActor
+{
+public:
+    using UActor::UActor;
+};
+
+class UXBeamEmitter : public UXEmitter
+{
+public:
+    using UXEmitter::UXEmitter;
+
+    BitfieldBool bDoBeamNoise() { return BoolValue(PropOffsets_XBeamEmitter.bDoBeamNoise); }
+    BitfieldBool bDynamicNoise() { return BoolValue(PropOffsets_XBeamEmitter.bDynamicNoise); }
+    Array<float> BeamPointScaling() { return DynamicArray<float>(PropOffsets_XBeamEmitter.BeamPointScaling); }
+    Array<FBeamTargetPoint> BeamTarget() { return DynamicArray<FBeamTargetPoint>(PropOffsets_XBeamEmitter.BeamTarget); }
+    UTexture*& EndTexture() { return Value<UTexture*>(PropOffsets_XBeamEmitter.EndTexture); }
+    RangeVector*& NoiseRange() { return Value<RangeVector*>(PropOffsets_XBeamEmitter.NoiseRange); }
+    float& NoiseSwapTime() { return Value<float>(PropOffsets_XBeamEmitter.NoiseSwapTime); }
+    Array<ScaleRangeType> NoiseTimeScale() { return DynamicArray<ScaleRangeType>(PropOffsets_XBeamEmitter.NoiseTimeScale); }
+    UMesh*& RenderDataModel() { return Value<UMesh*>(PropOffsets_XBeamEmitter.RenderDataModel); }
+    uint8_t& Segments() { return Value<uint8_t>(PropOffsets_XBeamEmitter.Segments); }
+    Array<float> SegmentScales() { return DynamicArray<float>(PropOffsets_XBeamEmitter.SegmentScales); }
+    UTexture*& StartTexture() { return Value<UTexture*>(PropOffsets_XBeamEmitter.StartTexture); }
+    FixedArrayView<float, 4> TextureUV() { return FixedArray<float, 4>(PropOffsets_XBeamEmitter.TextureUV); }
+    float& TurnRate() { return Value<float>(PropOffsets_XBeamEmitter.TurnRate); }
+};

--- a/SurrealEngine/UObject/UClass.cpp
+++ b/SurrealEngine/UObject/UClass.cpp
@@ -506,17 +506,17 @@ UClass::UClass(NameString name, UClass* base, ObjectFlags flags) : UState(std::m
 			objInternal->ArrayDimension = 6;
 			Properties.push_back(objInternal);
 		}
-		else if (!engine->LaunchInfo.IsUnreal1_227()) // Unreal 227 has removed ObjectInternal entirely
+		else if (!engine->LaunchInfo.IsUnreal1_227k()) // Unreal 227k has removed ObjectInternal entirely
 		{
 			auto objInternal = GC::Alloc<UIntProperty>("ObjectInternal", nullptr, ObjectFlags::Native);
 			objInternal->ArrayDimension = 6;
 			Properties.push_back(objInternal);
 		}
 
-		if (engine->LaunchInfo.IsUnreal1_227())
+		if (engine->LaunchInfo.IsUnreal1_227k())
 			Properties.push_back(GC::Alloc<UIntProperty>("ObjectIndex", nullptr, ObjectFlags::Native));
 		Properties.push_back(GC::Alloc<UObjectProperty>("Outer", nullptr, ObjectFlags::Native));
-		if (engine->LaunchInfo.IsUnreal1_227())
+		if (engine->LaunchInfo.IsUnreal1_227k())
 			Properties.push_back(GC::Alloc<UObjectProperty>("ObjectArchetype", nullptr, ObjectFlags::Native));
 		Properties.push_back(GC::Alloc<UIntProperty>("ObjectFlags", nullptr, ObjectFlags::Native));
 		Properties.push_back(GC::Alloc<UNameProperty>("Name", nullptr, ObjectFlags::Native));

--- a/SurrealEngine/UObject/UMesh.cpp
+++ b/SurrealEngine/UObject/UMesh.cpp
@@ -927,3 +927,43 @@ void UAnimation::Save(PackageStreamWriter* stream)
 		Moves.push_back(move);
 	}
 }
+
+/////////////////////////////////////////////////////////////////////////////
+
+void UStaticMesh::Load(ObjectStream* stream)
+{
+	LogUnimplemented("Static Mesh loading");
+
+	// UMesh::Load(stream);
+
+	/*
+	FlipNormals = stream->ReadUInt8();
+
+	const int NumLODLevels = stream->ReadIndex();
+	for (int i = 0 ; i < NumLODLevels ; i++)
+	{
+		StaticMeshLODLevel LODLevel;
+		LODLevel.LODBias = stream->ReadFloat();
+		LODLevel.StaticMesh = stream->ReadObject<UStaticMesh>();
+		LODLevels.push_back(LODLevel);
+	}
+
+	const int NumMaterials = stream->ReadIndex();
+	for (int i = 0; i < NumMaterials; i++)
+	{
+		MeshMaterial material;
+		material.PolyFlags = stream->ReadUInt32();
+		material.TextureIndex = stream->ReadInt32();
+		Materials.push_back(material);
+	}
+
+	SmoothCorners = stream->ReadUInt8();
+	UseSimpleBoxCollision = stream->ReadUInt8();
+	UseSimpleLineCollision = stream->ReadUInt8();
+	*/
+}
+
+void UStaticMesh::Save(PackageStreamWriter* stream)
+{
+	LogUnimplemented("Static Mesh saving");
+}

--- a/SurrealEngine/UObject/UMesh.h
+++ b/SurrealEngine/UObject/UMesh.h
@@ -7,6 +7,7 @@
 
 class UTexture;
 class UAnimation;
+class UStaticMesh;
 
 struct MeshTri
 {
@@ -235,4 +236,26 @@ public:
 
 	Array<RefBone> RefBones;
 	Array<AnimMove> Moves;
+};
+
+struct StaticMeshLODLevel
+{
+	float LODBias = 0.0;
+	UStaticMesh* StaticMesh = nullptr;
+};
+
+class UStaticMesh : public UMesh
+{
+public:
+	using UMesh::UMesh;
+
+	void Load(ObjectStream* stream) override;
+	void Save(PackageStreamWriter* stream) override;
+
+	bool FlipNormals = false;
+	Array<StaticMeshLODLevel> LODLevels;
+	Array<MeshMaterial> Materials;
+	bool SmoothCorners = false;
+	bool UseSimpleBoxCollision = false;
+	bool UseSimpleLineCollision = false;
 };


### PR DESCRIPTION
Some of the stuff I claimed to be added to Object in 227 turns out to be added on 227**k** specifically (or maybe j, I haven't tested it), meaning Object in 227i still has `ObjectInternal` and such.

Gating these additions to a specific IsUnreal1_227k() check seems to do the trick. Unreal 227i boots up but crashes on an iterator error before we can load the flyby level.

Edit: Added some `Emitter` classes to the mix, as well as some stubs for `StaticMesh`