### PR TITLE
Added support for reading System64 executables such as ut-bin-amd64.

### DIFF
--- a/SurrealEngine/UE1GameDatabase.cpp
+++ b/SurrealEngine/UE1GameDatabase.cpp
@@ -1,6 +1,6 @@
 #include "UE1GameDatabase.h"
-
 #include "Utils/SHA1Sum.h"
+#include <iostream>
 
 std::pair<KnownUE1Games, std::string> FindUE1GameInPath(const std::string& ue1_game_root_folder_path)
 {
@@ -11,27 +11,30 @@ std::pair<KnownUE1Games, std::string> FindUE1GameInPath(const std::string& ue1_g
 		return std::make_pair(KnownUE1Games::UE1_GAME_NOT_FOUND, "");
 
 	const auto UE1GameSystemPath = fs::path(ue1_game_root_folder_path) / "System";
+	const auto UE1GameSystem64Path = fs::path(ue1_game_root_folder_path) / "System64";
 
 	for (auto& executable_name : knownUE1ExecutableNames)
 	{
 		auto executablePath = UE1GameSystemPath / executable_name;
+		auto executablePath64 = UE1GameSystem64Path / executable_name;
+		std::cout << "PATH64: " << executablePath64 << std::endl;
 
 		std::string sha1sum = SHA1Sum::of_file(executablePath);
+		std::string sha1sum64 = SHA1Sum::of_file(executablePath64);
 
 		// If sha1sum is empty this means that the file doesn't exist
-		if (sha1sum.empty())
+		if (sha1sum.empty() && sha1sum64.empty())
 			continue;
 
 		// Now check whether there is a match within the database or not
-		const auto it = SHA1Database.find(sha1sum);
-
+		const auto it = !sha1sum.empty() ? SHA1Database.find(sha1sum) : SHA1Database.find(sha1sum64);
+		
 		if (it == SHA1Database.end())
 			return std::make_pair(KnownUE1Games::UE1_GAME_NOT_FOUND, "");
 
 		// Hack: Tactical-Ops has a version that contains the exact same UTv469d executable. Handle that here
 		if (it->second == KnownUE1Games::UT99_469d && executable_name == "TacticalOps.exe")
 			return std::make_pair(KnownUE1Games::TACTICAL_OPS_469, executable_name);
-
 		return std::make_pair(it->second, executable_name);
 	}
 

--- a/SurrealEngine/UE1GameDatabase.h
+++ b/SurrealEngine/UE1GameDatabase.h
@@ -139,7 +139,7 @@ static const std::map<std::string, KnownUE1Games> SHA1Database = {
 	// Linux 32 bit (ut-bin-x86)
 	{"412cb72ae6deac8073e49ccad78904a415b90cf8", KnownUE1Games::UT99_469e},
 	// Linux 64 bit (ut-bin-amd64)
-	{"412cb72ae6deac8073e49ccad78904a415b90cf8", KnownUE1Games::UT99_469e},
+	{"eba30e88bcbff2d778f68865c047c238814dfd9c", KnownUE1Games::UT99_469e},
 
 	// Deus Ex, v1002f
 	{"9f923d667a396e8243028c14dc3f5e0a6db13d84", KnownUE1Games::DEUS_EX_1002f},
@@ -187,6 +187,7 @@ static const Array<std::string> knownUE1ExecutableNames = {
 	"UnrealTournament.exe",
 	"ut-bin",
 	"ut-bin-x86",
+	"ut-bin-amd64",
 	"ut-bin-x64",
 	"DeusEx.exe",
 	"Klingons.exe",


### PR DESCRIPTION
Since the System64 directory OU v469e uses for its executables didn't get read, I added it and the checksums for the 64 bit version. Now UTv469e is detected in 64-bit computers. 