### PR TITLE
AllActors fixes for Unreal 227i

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -573,7 +573,8 @@ UnrealURL Engine::GetDefaultURL(const std::string& map)
 void Engine::LoadEntryMap()
 {
 	// The entry map is the map you see in the game when no other map is playing. For example when disconnected from a server. It is always loaded and running.
-	LoadMap(GetDefaultURL("Entry"));
+	const auto entryMapName = packages->GetIniValue("System", "URL", "EntryMap", "Entry");
+	LoadMap(GetDefaultURL(entryMapName));
 	EntryLevelInfo = LevelInfo;
 	EntryLevel = Level;
 	EntryLevelPackage = std::move(LevelPackage);
@@ -1278,6 +1279,17 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 		// "mpgameplay"
 		// "mpinstall"
 		return "mpgameplay";
+	}
+	else if (command == "os")
+	{
+		// 227 Seems to have this command
+#ifdef WIN32
+		return "Windows";
+#elif APPLE
+		return "macOS";
+#else
+		return "Linux"; // With apologies to BSD, Haiku and others...
+#endif
 	}
 	else if (command == "getsplash")
 	{

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -1285,7 +1285,7 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 		// 227 Seems to have this command
 #ifdef WIN32
 		return "Windows";
-#elif APPLE
+#elif __APPLE__
 		return "macOS";
 #else
 		return "Linux"; // With apologies to BSD, Haiku and others...

--- a/SurrealEngine/Native/NActor.cpp
+++ b/SurrealEngine/Native/NActor.cpp
@@ -19,7 +19,7 @@ void NActor::RegisterFunctions()
 	if (engine->LaunchInfo.IsUnreal1_227k())
 		RegisterVMNativeFunc_5("Actor", "AllActors", &NActor::AllActors_U227k, 304);
 	else if (engine->LaunchInfo.IsUnreal1_227())
-		RegisterVMNativeFunc_5("Actor", "AllActors", &NActor::AllActors_U227, 304);
+		RegisterVMNativeFunc_4("Actor", "AllActors", &NActor::AllActors_U227, 304);
 	else
 		RegisterVMNativeFunc_3("Actor", "AllActors", &NActor::AllActors, 304);
 	RegisterVMNativeFunc_1("Actor", "AutonomousPhysics", &NActor::AutonomousPhysics, 3971);
@@ -135,7 +135,7 @@ void NActor::AllActors(UObject* Self, UObject* BaseClass, UObject*& Actor, std::
 
 void NActor::AllActors_U227(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent)
 {
-	Frame::CreatedIterator = std::make_unique<AllActorsIterator>(BaseClass, &Actor, MatchTag ? *MatchTag : std::string(), MatchEvent ? *MatchEvent : std::string(), false);
+	Frame::CreatedIterator = std::make_unique<AllActorsIterator>(BaseClass, &Actor, MatchTag ? *MatchTag : std::string(), MatchEvent ? *MatchEvent : std::string());
 }
 
 void NActor::AllActors_U227k(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<NameString> MatchTag, std::optional<NameString> MatchEvent, bool bAllLevels)

--- a/SurrealEngine/Native/NObject.cpp
+++ b/SurrealEngine/Native/NObject.cpp
@@ -197,7 +197,7 @@ void NObject::RegisterFunctions()
 		RegisterVMNativeFunc_3("Object", "AlignQuatWith", &NObject::AlignQuatWith_U227, 634);
 		RegisterVMNativeFunc_3("Object", "AllFiles", &NObject::AllFiles_U227, 603);
 		RegisterVMNativeFunc_7("Object", "AllLinkers", &NObject::AllLinkers_U227, 636);
-		RegisterVMNativeFunc_3("Object", "AllObjects", &NObject::AllObjects_U227, 304);
+		RegisterVMNativeFunc_3("Object", "AllObjects", &NObject::AllObjects_U227, 602);
 		RegisterVMNativeFunc_3("Object", "And_RotatorRotator", &NObject::And_RotatorRotator_U227, 607);
 		RegisterVMNativeFunc_1("Object", "AppSeconds", &NObject::AppSeconds_U227, 643);
 		RegisterVMNativeFunc_1("Object", "AppInEditor", &NObject::AppInEditor_U227, 645);

--- a/SurrealEngine/VM/Iterator.cpp
+++ b/SurrealEngine/VM/Iterator.cpp
@@ -37,6 +37,11 @@ AllActorsIterator::AllActorsIterator(UObject* BaseClass, UObject** ReturnValue, 
 {
 }
 
+AllActorsIterator::AllActorsIterator(UObject* BaseClass, UObject** ReturnValue, NameString MatchTag, NameString MatchEvent)
+	: BaseClass(BaseClass), ReturnValue(ReturnValue), MatchTag(MatchTag), MatchEvent(MatchEvent)
+{
+}
+
 AllActorsIterator::AllActorsIterator(UObject* BaseClass, UObject** ReturnValue, NameString MatchTag, NameString MatchEvent, bool bAllLevels)
 	: BaseClass(BaseClass), ReturnValue(ReturnValue), MatchTag(MatchTag), MatchEvent(MatchEvent), bAllLevels(bAllLevels)
 {

--- a/SurrealEngine/VM/Iterator.h
+++ b/SurrealEngine/VM/Iterator.h
@@ -49,16 +49,18 @@ class AllActorsIterator : public Iterator
 {
 public:
 	AllActorsIterator(UObject* BaseClass, UObject** ReturnValue, NameString MatchTag);
-	// Unreal 227 version of AllActors
+	// Unreal 227i version of AllActors
+	AllActorsIterator(UObject* BaseClass, UObject** ReturnValue, NameString MatchTag, NameString MatchEvent);
+	// Unreal 227k version of AllActors
 	// TODO: Handle bAllLevels parameter
-	AllActorsIterator(UObject* BaseClass, UObject** ReturnValue, NameString MatchTag, NameString MatchEvent, bool bAllLevels = false);
+	AllActorsIterator(UObject* BaseClass, UObject** ReturnValue, NameString MatchTag, NameString MatchEvent, bool bAllLevels);
 	bool Next() override;
 
 private:
 	UObject* BaseClass = nullptr;
 	UObject** ReturnValue = nullptr;
-	NameString MatchTag;
-	NameString MatchEvent;
+	NameString MatchTag = "";
+	NameString MatchEvent = "";
 	bool bAllLevels = false;
 	size_t index = 0;
 };

--- a/SurrealEngine/VM/NativeFunc.cpp
+++ b/SurrealEngine/VM/NativeFunc.cpp
@@ -12,6 +12,12 @@ void NativeFunctions::RegisterHandler(const NameString& className, const NameStr
 	if (nativeIndex != 0)
 	{
 		if (NativeByIndex.size() <= (size_t)nativeIndex) NativeByIndex.resize((size_t)nativeIndex + 1);
+
+		if (NativeByIndex[nativeIndex] != nullptr)
+			Exception::Throw("Attempted to assign native index "
+				+ std::to_string(nativeIndex) + " to " + className.ToString() + "." + funcName.ToString()
+				+ ", which was already assigned to a different native function.");
+
 		NativeByIndex[nativeIndex] = handler;
 	}
 	else
@@ -22,10 +28,17 @@ void NativeFunctions::RegisterHandler(const NameString& className, const NameStr
 
 void NativeFunctions::RegisterNativeFunc(UFunction* func)
 {
-	int nativeIndex = func->NativeFuncIndex;;
+	int nativeIndex = func->NativeFuncIndex;
+	
 	if (nativeIndex != 0)
 	{
 		if (FuncByIndex.size() <= (size_t)nativeIndex) FuncByIndex.resize((size_t)nativeIndex + 1);
+
+		if (FuncByIndex[nativeIndex] != nullptr)
+			Exception::Throw("Attempted to assign native index "
+				+ std::to_string(nativeIndex) + " to " + UObject::GetUClassFullName(func).ToString()
+				+ ", which was already assigned to a different native function.");
+
 		FuncByIndex[nativeIndex] = func;
 	}
 }


### PR DESCRIPTION
The problem turned out to be `Object.AllObjects()` and `Actor.AllActors()` having accidentally assigned the same native index.

Not only I fixed that, I also modified the relevant functions to throw an exception when such an event happens again.

Also implemented the "os" command while I'm at it. It returns the OS's name the engine is currently running on.

Lastly we're now checking the Entry map name from the system ini file.

Sadly we're still crashing while trying to booting 227i up, this time it is because `Object.Array_Size()` not being implemented.