### PR TITLE
Add more 227 stuff

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -618,9 +618,9 @@ void Engine::LoadMap(const UnrealURL& url, const std::map<std::string, std::stri
 
 	LevelInfo->ComputerName() = "MyComputer";
 	LevelInfo->HubStackLevel() = 0; // To do: handle level hubs
-	LevelInfo->EngineVersion() = std::to_string(LaunchInfo.engineVersion) + " SE";
+	LevelInfo->EngineVersion() = LaunchInfo.gameVersionString + " SE";
 	if (packages->GetEngineVersion() > 219)
-		LevelInfo->MinNetVersion() = std::to_string(LaunchInfo.engineVersion) + " SE";
+		LevelInfo->MinNetVersion() = LaunchInfo.gameVersionString + " SE";
 	LevelInfo->bHighDetailMode() = true;
 	LevelInfo->NetMode() = 0; // NM_StandAlone
 	LevelInfo->DefaultTexture() = engine->DefaultTexture;
@@ -737,9 +737,9 @@ void Engine::LoadFromSaveFile(const UnrealURL& url)
 	LevelInfo->ComputerName() = "MyComputer";
 	LevelInfo->HubStackLevel() = 0; // To do: handle level hubs
 	*/
-	LevelInfo->EngineVersion() = std::to_string(LaunchInfo.engineVersion) + " SE";
+	LevelInfo->EngineVersion() = LaunchInfo.gameVersionString + " SE";
 	if (packages->GetEngineVersion() > 219)
-		LevelInfo->MinNetVersion() = std::to_string(LaunchInfo.engineVersion) + " SE";
+		LevelInfo->MinNetVersion() = LaunchInfo.gameVersionString + " SE";
 	LevelInfo->bHighDetailMode() = true;
 	/*
 	LevelInfo->NetMode() = 0; // NM_StandAlone

--- a/SurrealEngine/Native/NObject.cpp
+++ b/SurrealEngine/Native/NObject.cpp
@@ -197,6 +197,9 @@ void NObject::RegisterFunctions()
 		RegisterVMNativeFunc_3("Object", "AllFiles", &NObject::AllFiles_U227, 603);
 		RegisterVMNativeFunc_7("Object", "AllLinkers", &NObject::AllLinkers_U227, 636);
 		RegisterVMNativeFunc_3("Object", "AllObjects", &NObject::AllObjects_U227, 602);
+		RegisterVMNativeFunc_3("Object", "Array_Size", &NObject::Array_Size_U227, 640);
+		RegisterVMNativeFunc_4("Object", "Array_Insert", &NObject::Array_Insert_U227, 641);
+		RegisterVMNativeFunc_4("Object", "Array_Remove", &NObject::Array_Remove_U227, 642);
 		RegisterVMNativeFunc_3("Object", "And_RotatorRotator", &NObject::And_RotatorRotator_U227, 607);
 		RegisterVMNativeFunc_1("Object", "AppSeconds", &NObject::AppSeconds_U227, 643);
 		RegisterVMNativeFunc_1("Object", "AppInEditor", &NObject::AppInEditor_U227, 645);

--- a/SurrealEngine/UObject/UMesh.cpp
+++ b/SurrealEngine/UObject/UMesh.cpp
@@ -934,7 +934,9 @@ void UStaticMesh::Load(ObjectStream* stream)
 {
 	LogUnimplemented("Static Mesh loading");
 
-	// UMesh::Load(stream);
+	// UMesh::Load() doesn't work for some reason
+	// We use UPrimitive::Load() for now so that we at least get an "Outer".
+	UPrimitive::Load(stream);
 
 	/*
 	FlipNormals = stream->ReadUInt8();


### PR DESCRIPTION
* Added missing function registering for 227's Array functions
* Engine will now show the full version string (e.g. 227i instead of 227)
* `UStaticMesh` at least loads the `UPrimitive` fields now so that we won't get crashes about engine failing to find "Outer"