### PR TITLE
More 227i fixes

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -31,7 +31,6 @@ At the time of this writing, SurrealEngine can **detect** the following UE1 game
 * Mirrors/reflections rendering is a bit buggy, especially around the edges of world geometry.
 * Portals:
   - They somewhat work, but might end up "pushing" players/projectiles in unexpected directions.
-  - No portal rendering yet.
 * Semisolid brushes are finicky. Usually you'll fall through them as if they weren't there.
 * No dynamic lighting support (Dispersion Pistol projectiles/Flares don't illuminate their surroundings)
 * Bot and Scripted Pawn AI isn't fully functional due to the related native functions not being implemented.
@@ -45,6 +44,7 @@ they end up dying because SE thinks that they've fallen from a great height.
 (and accumulates if a new power-up of the same type is picked up and activated) until the player switches to a different map.
 * viewclass command crashes with null deref.
 * Sometimes opening a map crashes the engine with a "Failed to spawn the player actor" error.
+* Sounds may become too loud (e.g. Pulse Rifle secondary fire, minigun firing sound)
 * Third person weapon meshes do not get rendered.
 * Inventory from loaded saves do NOT transfer to the next map.
 * Saving packages (.u[xx] files, game saves, etc.) functionality is not fully implemented yet.
@@ -59,17 +59,23 @@ they end up dying because SE thinks that they've fallen from a great height.
 
 ## Unreal (Gold)
 
-226 version of the game launches. Menu options works most of the time. Single player maps can be played, as well as botmatches. The AI will behave more or less the same as how they behave in UT.
+226 version of the game launches. Menu options works most of the time. Single player maps can be played, as well as botmatches. Bots can sometimes move around and attack.
+
+227i version of the game also launches. Single player maps can be played, as well as botmatches. Some menu items may not work, and lots of new features (e.g. Emitters, Static Meshes) are not implemented.
+
+227j patch isn't tested, while 227k_14 crashes immediately.
 
 ### Known Bugs:
 * [227*] Many new native functions/features are not yet implemented.
+* [227i] Translator Scale option does not do anything.
+* [227i] Opening up DmExar crashes SE with "Module file unsupported by OpenMPT" error.
 * Some UPak native functions are not implemented yet.
 * Nali Fruit Seeds and ASMDs in a map don't render, but are pickable.
 * ASMD tertiary fire rings render wrong.
 
 ## Unreal Tournament
 
-436 version of the game launches. Menu options will work and botmatches can be played, however the bots will barely have any AI (they move around sometimes and retaliate upon being attacked), and some maps might have some functionality missing.
+436 version of the game launches. Menu options will work and botmatches can be played. Bots will behave more or less like they do in Unreal and some maps might have some functionality missing.
 
 ### Known bugs:
 * [469*] Many new native functions/features are not yet implemented.
@@ -84,7 +90,7 @@ they end up dying because SE thinks that they've fallen from a great height.
 * Some native functions are still not implemented.
 * Conversation system is not fully implemented yet.
 * If you click on the area where the saves should be in the Load Game menu the buttons below stop working so you cannot go back.
-* In-game HUD is mostly invisible except for the Incoming Transmission part.
+* In-game HUD has some missing text.
 * DataCubes and books cannot be read yet.
 
 ## Tactical-Ops: Assault on Terror

--- a/SurrealEngine/Native/NActor.cpp
+++ b/SurrealEngine/Native/NActor.cpp
@@ -106,6 +106,12 @@ void NActor::RegisterFunctions()
 	RegisterVMNativeFunc_10("Actor", "TraceTexture", &NActor::TraceTexture, 1000);
 	RegisterVMNativeFunc_7("Actor", "TraceVisibleActors", &NActor::TraceVisibleActors, 1003);
 
+	if (engine->LaunchInfo.IsUnreal1_227())
+	{
+		RegisterVMNativeFunc_7("Actor", "TraceSurfHitInfo", &NActor::TraceSurfHitInfo_U227, 1736);
+		RegisterVMNativeFunc_6("Actor", "TraceThisActor", &NActor::TraceThisActor_U227, 1739);
+	}
+
 	if (engine->LaunchInfo.IsDeusEx())
 	{
 		RegisterVMNativeFunc_1("Actor", "InStasis", &NActor::InStasis, 721);
@@ -804,6 +810,21 @@ void NActor::TraceVisibleActors(UObject* Self, UObject* BaseClass, UObject*& Act
 	vec3 realExtent = Extent ? *Extent : vec3(0, 0, 0);
 
 	Frame::CreatedIterator = std::make_unique<TraceVisibleActorsIterator>(BaseClass, &Actor, HitLoc, HitNorm, End, &realStart, &realExtent);
+}
+
+void NActor::TraceSurfHitInfo_U227(UObject* Self, vec3& Start, vec3& End, vec3* HitLocation, vec3* HitNormal, UObject* HitTex, int* HitFlags, BitfieldBool& ReturnValue)
+{
+	auto SelfActor = UObject::Cast<UActor>(Self);
+	auto Tex = UObject::Cast<UTexture>(HitTex);
+
+	ReturnValue = SelfActor->TraceSurfHitInfo(Start, End, HitLocation, HitNormal, Tex, HitFlags);
+}
+
+void NActor::TraceThisActor_U227(UObject* Self, vec3& TraceEnd, vec3& TraceStart, vec3* HitLocation, vec3* HitNormal, std::optional<vec3> Extent, BitfieldBool& ReturnValue)
+{
+	auto SelfActor = UObject::Cast<UActor>(Self);
+
+	ReturnValue = SelfActor->TraceThisActor(TraceEnd, TraceStart, HitLocation, HitNormal, Extent);
 }
 
 void NActor::InStasis(UObject* Self, BitfieldBool& ReturnValue)

--- a/SurrealEngine/Native/NActor.h
+++ b/SurrealEngine/Native/NActor.h
@@ -66,6 +66,8 @@ public:
 	static void TouchingActors(UObject* Self, UObject* BaseClass, UObject*& Actor);
 	static void Trace(UObject* Self, vec3& HitLocation, vec3& HitNormal, const vec3& TraceEnd, std::optional<vec3> TraceStart, std::optional<bool> bTraceActors, std::optional<vec3> Extent, UObject*& ReturnValue);
 	static void TraceActors(UObject* Self, UObject* BaseClass, UObject*& Actor, vec3& HitLoc, vec3& HitNorm, const vec3& End, std::optional<vec3> Start, std::optional<vec3> Extent);
+	static void TraceSurfHitInfo_U227(UObject* Self, vec3& Start, vec3& End, vec3* HitLocation, vec3* HitNormal, UObject* HitTex, int* HitFlags, BitfieldBool& ReturnValue);
+	static void TraceThisActor_U227(UObject* Self, vec3& TraceEnd, vec3& TraceStart, vec3* HitLocation, vec3* HitNormal, std::optional<vec3> Extent, BitfieldBool& ReturnValue);
 	static void TweenAnim(UObject* Self, const NameString& Sequence, float Time);
 	static void VisibleActors(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<float> Radius, std::optional<vec3> Loc);
 	static void VisibleCollidingActors(UObject* Self, UObject* BaseClass, UObject*& Actor, std::optional<float> Radius, std::optional<vec3> Loc, std::optional<bool> bIgnoreHidden);

--- a/SurrealEngine/Native/NObject.cpp
+++ b/SurrealEngine/Native/NObject.cpp
@@ -155,8 +155,8 @@ void NObject::RegisterFunctions()
 	RegisterVMNativeFunc_0("Object", "ResetConfig", &NObject::ResetConfig, 0);
 	RegisterVMNativeFunc_3("Object", "Right", &NObject::Right, 234);
 	RegisterVMNativeFunc_2("Object", "RotRand", &NObject::RotRand, 320);
-	if (engine->LaunchInfo.IsUnreal1_227())
-		RegisterVMNativeFunc_1("Object", "SaveConfig", &NObject::SaveConfig_U227, 536);
+	if (engine->LaunchInfo.IsUnreal1_227k())
+		RegisterVMNativeFunc_1("Object", "SaveConfig", &NObject::SaveConfig_U227k, 536);
 	else
 		RegisterVMNativeFunc_0("Object", "SaveConfig", &NObject::SaveConfig, 536);
 	RegisterVMNativeFunc_2("Object", "SetPropertyText", &NObject::SetPropertyText, 0);
@@ -1422,10 +1422,9 @@ void NObject::SaveConfig(UObject* Self)
 	Self->SaveConfig();
 }
 
-void NObject::SaveConfig_U227(UObject* Self, std::optional<bool> bNoWriteINI)
+void NObject::SaveConfig_U227k(UObject* Self, std::optional<bool> bNoWriteINI)
 {
-	if (engine->LaunchInfo.IsUnreal1_227())
-		LogUnimplemented("Object.SaveConfig() [U227 - bNoWriteINI parameter not implemented]");
+	LogUnimplemented("Object.SaveConfig() [U227k - bNoWriteINI parameter not implemented]");
 	Self->SaveConfig();
 }
 

--- a/SurrealEngine/Native/NObject.h
+++ b/SurrealEngine/Native/NObject.h
@@ -205,7 +205,7 @@ public:
 	static void RotationToQuat_U227(Rotator& R, quaternion& ReturnValue);
 	static void RotRand(std::optional<bool> bRoll, Rotator& ReturnValue);
 	static void SaveConfig(UObject* Self);
-	static void SaveConfig_U227(UObject* Self, std::optional<bool> bNoWriteINI); // bNoWriteINI is false by default. If it is true, don't write the config to ini, and wait for the next SaveConfig() call.
+	static void SaveConfig_U227k(UObject* Self, std::optional<bool> bNoWriteINI); // bNoWriteINI is false by default. If it is true, don't write the config to ini, and wait for the next SaveConfig() call.
 	static void SetPropertyText(UObject* Self, const std::string& PropName, const std::string& PropValue);
 	static void Sin(float A, float& ReturnValue);
 	static void SlerpRotation_U227(Rotator& Dest, Rotator& Src, float Alpha, Rotator& ReturnValue); // Will use quaternion for actual shortest rotation

--- a/SurrealEngine/Package/Package.cpp
+++ b/SurrealEngine/Package/Package.cpp
@@ -13,8 +13,8 @@ Package::Package(PackageManager* packageManager, const NameString& name, const s
 	if (!filepath.empty())
 		ReadTables();
 
-	FileName = fs::path(FilePath).filename();
-	FileExtension = fs::path(FilePath).extension();
+	FileName = fs::path(FilePath).filename().string();
+	FileExtension = fs::path(FilePath).extension().string();
 
 	// Register native classes not listed in the package
 	for (const auto& it : packageManager->NativeClasses)

--- a/SurrealEngine/Package/Package.cpp
+++ b/SurrealEngine/Package/Package.cpp
@@ -8,10 +8,13 @@
 #include "UObject/UObject.h"
 #include "UObject/UClass.h"
 
-Package::Package(PackageManager* packageManager, const NameString& name, const std::string& filename) : Packages(packageManager), Name(name), Filename(filename)
+Package::Package(PackageManager* packageManager, const NameString& name, const std::string& filepath) : Packages(packageManager), Name(name), FilePath(filepath)
 {
-	if (!filename.empty())
+	if (!filepath.empty())
 		ReadTables();
+
+	FileName = fs::path(FilePath).filename();
+	FileExtension = fs::path(FilePath).extension();
 
 	// Register native classes not listed in the package
 	for (const auto& it : packageManager->NativeClasses)

--- a/SurrealEngine/Package/Package.h
+++ b/SurrealEngine/Package/Package.h
@@ -16,7 +16,7 @@ class UClass;
 class Package : public GCObject
 {
 public:
-	Package(PackageManager* packageManager, const NameString& name, const std::string& filename);
+	Package(PackageManager* packageManager, const NameString& name, const std::string& filepath);
 	~Package();
 
 	UObject* NewObject(const NameString& objname, UClass* objclass, ObjectFlags flags, bool initProperties = true);
@@ -33,7 +33,9 @@ public:
 	const NameString& GetName(int index) const;
 	int GetVersion() const { return Version; }
 	NameString GetPackageName() const { return Name; }
-	std::string GetPackageFilename() const { return Filename; }
+	std::string GetPackageFileName() const { return FileName; }
+	std::string GetPackageFilePath() const { return FilePath; }
+	std::string GetPackageFileExtension() const { return FileExtension; }
 
 	PackageManager* GetPackageManager() { return Packages; }
 
@@ -54,7 +56,9 @@ private:
 
 	PackageManager* Packages = nullptr;
 	NameString Name;
-	std::string Filename;
+	std::string FilePath;
+	std::string FileName;
+	std::string FileExtension;
 
 	int Version = 0;
 	int LicenseeMode = 0;

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -385,7 +385,7 @@ std::shared_ptr<PackageStream> PackageManager::GetStream(Package* package)
 
 	OpenStream s;
 	s.Pkg = package;
-	s.Stream = std::make_shared<PackageStream>(package, File::open_existing(package->GetPackageFilename()));
+	s.Stream = std::make_shared<PackageStream>(package, File::open_existing(package->GetPackageFilePath()));
 	openStreams.push_front(s);
 
 	if (numStreams == 10)

--- a/SurrealEngine/Package/PackageWriter.cpp
+++ b/SurrealEngine/Package/PackageWriter.cpp
@@ -18,7 +18,7 @@ void PackageWriter::Save(UObject* packageObject, std::string filename)
 	Source->LoadAll();
 
 	if (filename.empty())
-		filename = Source->GetPackageFilename();
+		filename = Source->GetPackageFilePath();
 
 	const std::string tempFilename = fs::path(filename).replace_extension(".tmp").string();
 
@@ -50,7 +50,7 @@ void PackageWriter::Save(UObject* packageObject, std::string filename)
 
 		File::rename(tempFilename, filename);
 
-		if (filename == Source->GetPackageFilename()) // To do: should we search all open packages?
+		if (filename == Source->GetPackageFilePath()) // To do: should we search all open packages?
 		{
 			Source->NameTable = std::move(NameTable);
 			Source->NameHash = std::move(NameHash);

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -1451,6 +1451,56 @@ bool UActor::FastTrace(const vec3& traceEnd, const vec3& traceStart)
 	return !XLevel()->Collision.TraceAnyHit(traceStart, traceEnd, this, false, true, false);
 }
 
+bool UActor::TraceSurfHitInfo(vec3& Start, vec3& End, vec3* HitLocation, vec3* HitNormal, UTexture* HitTex, int* HitFlags)
+{
+	const TraceFlags flags = {
+		.movers = true,
+		.world = true
+	};
+
+	const auto hit = XLevel()->Collision.TraceFirstHit(Start, End, this, vec3(), flags);
+
+	if (!hit.Node)
+		return false;
+
+	if (HitLocation)
+		*HitLocation = Start + (End - Start) * hit.Fraction;
+
+	if (HitNormal)
+		*HitNormal = hit.Normal;
+
+	if (HitTex)
+		HitTex = XLevel()->Model->Surfaces[hit.Node->Surf].Material;
+
+	if (HitFlags)
+		*HitFlags = hit.Node->NodeFlags;
+
+	return true;
+}
+
+bool UActor::TraceThisActor(vec3& TraceEnd, vec3 TraceStart, vec3* HitLocation, vec3* HitNormal, std::optional<vec3> Extent)
+{
+	TraceFlags flags {
+		.pawns = true,
+		.movers = true,
+		.others = true,
+		.world = true
+	};
+
+	const auto hit = XLevel()->Collision.TraceFirstHit(TraceStart, TraceEnd, this, Extent ? *Extent : vec3(), flags);
+
+	if (!hit.Node && !hit.Actor)
+		return false;
+
+	if (HitLocation)
+		*HitLocation = TraceStart + (TraceEnd - TraceStart) * hit.Fraction;
+
+	if (HitNormal)
+		*HitNormal = hit.Normal;
+
+	return true;
+}
+
 bool UActor::IsBasedOn(UActor* other)
 {
 	for (UActor* cur = other; cur; cur = cur->ActorBase())

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -415,6 +415,10 @@ public:
 
 	UObject* Trace(vec3& hitLocation, vec3& hitNormal, const vec3& traceEnd, const vec3& traceStart, bool bTraceActors, const vec3& extent);
 	bool FastTrace(const vec3& traceEnd, const vec3& traceStart);
+	// Unreal 227 - Trace against world and return the wanted information (location, normal, texture and/or polyflags)
+	bool TraceSurfHitInfo(vec3& Start, vec3& End, vec3* HitLocation, vec3* HitNormal, UTexture* HitTex, int* HitFlags);
+	// Unreal 227 - Perform a single line check with this actor
+	bool TraceThisActor(vec3& TraceEnd, vec3 TraceStart, vec3* HitLocation, vec3* HitNormal, std::optional<vec3> Extent);
 
 	CollisionHit TryMove(const vec3 & delta, bool dryRun = false, bool isOwnBaseBlocking = true);
 	CollisionHit TryMoveSmooth(const vec3& delta);

--- a/SurrealEngine/UObject/UProperty.cpp
+++ b/SurrealEngine/UObject/UProperty.cpp
@@ -1107,6 +1107,10 @@ void UStructProperty::Load(ObjectStream* stream)
 		ValueType = ExpressionValueType::ValueRotator;
 	else if (Struct->Name == "Color")
 		ValueType = ExpressionValueType::ValueColor;
+	else if (Struct->Name == "Coords")
+		ValueType = ExpressionValueType::ValueCoords;
+	else if (Struct->Name == "Quat")
+		ValueType = ExpressionValueType::ValueQuat;
 }
 
 void UStructProperty::Save(PackageStreamWriter* stream)

--- a/SurrealEngine/VM/Iterator.cpp
+++ b/SurrealEngine/VM/Iterator.cpp
@@ -2,6 +2,7 @@
 #include "Precomp.h"
 #include "Iterator.h"
 #include "Utils/File.h"
+#include "Utils/StrTools.h"
 #include "Engine.h"
 #include "Package/PackageManager.h"
 #include "UObject/ULevel.h"
@@ -78,10 +79,10 @@ AllFilesIterator::AllFilesIterator(const std::string& FileExtension, const std::
 	{
 		auto package = engine->packages->GetPackage(packageName);
 
-		if ((FileExtension.empty() || fs::path(package->GetPackageFilename()).extension().string() == FileExtension) &&
-			(FilePrefix.empty() || package->GetPackageFilename().find(FilePrefix) != std::string::npos))
+		if ((FileExtension.empty() || package->GetPackageFileExtension() == "." + FileExtension) &&
+			(FilePrefix.empty() || StrTools::startswith(package->GetPackageFileName(), FilePrefix, true)))
 		{
-			FoundFiles.push_back(packageName.ToString());
+			FoundFiles.push_back(package->GetPackageFileName());
 		}
 	}
 


### PR DESCRIPTION
* Fixed `AllFilesIterator`, so that maps section in the Botmatch menu is fully populated
* Fixed the wrong version of `Object.SaveConfig()` being used for 227i, causing a crash
* Implemented `Actor.TraceSurfHitInfo()` and `Actor.TraceThisActor()`
* Added Quaternion and Coords values handling to `UStructProperty`

With these changes, we can `open` maps, play botmatches and start the single player campaign in 227i.

Also updated the docs to reflect the current status of SE.