### PR TITLE
Moar 227 stuff

### DIFF
--- a/SurrealEngine/Native/NActor.cpp
+++ b/SurrealEngine/Native/NActor.cpp
@@ -84,9 +84,13 @@ void NActor::RegisterFunctions()
 	RegisterVMNativeFunc_1("Actor", "Sleep", &NActor::Sleep, 256);
 	RegisterLatentAction(257, LatentRunState::Sleep);
 	RegisterVMNativeFunc_6("Actor", "Spawn", &NActor::Spawn, 278);
-	RegisterVMNativeFunc_3("Actor", "Subtract_ColorColor", &NActor::Subtract_ColorColor, 549);
+	if (!engine->LaunchInfo.IsUnreal1())
+		RegisterVMNativeFunc_3("Actor", "Subtract_ColorColor", &NActor::Subtract_ColorColor, 549); // U227 reserves this slot for PlayerPawn.IsPressing()
 	RegisterVMNativeFunc_2("Actor", "TouchingActors", &NActor::TouchingActors, 307);
-	RegisterVMNativeFunc_7("Actor", "Trace", &NActor::Trace, 277);
+	if (engine->LaunchInfo.IsUnreal1_227())
+		RegisterVMNativeFunc_9("Actor", "Trace", &NActor::Trace_U227, 277);
+	else
+		RegisterVMNativeFunc_7("Actor", "Trace", &NActor::Trace, 277);
 	RegisterVMNativeFunc_7("Actor", "TraceActors", &NActor::TraceActors, 309);
 	RegisterVMNativeFunc_2("Actor", "TweenAnim", &NActor::TweenAnim, 294);
 	RegisterVMNativeFunc_4("Actor", "VisibleActors", &NActor::VisibleActors, 311);
@@ -655,6 +659,18 @@ void NActor::Trace(UObject* Self, vec3& HitLocation, vec3& HitNormal, const vec3
 		TraceStart ? *TraceStart : SelfActor->Location(),
 		bTraceActors ? *bTraceActors : false,
 		Extent ? *Extent : vec3(0, 0, 0));
+}
+
+void NActor::Trace_U227(UObject* Self, vec3& HitLocation, vec3& HitNormal, const vec3& TraceEnd, std::optional<vec3> TraceStart, std::optional<bool> bTraceActors, std::optional<vec3> Extent, std::optional<bool> bTraceBSP, std::optional<uint8_t> BSPTraceFlags, UObject*& ReturnValue)
+{
+	auto SelfActor = UObject::Cast<UActor>(Self);
+	ReturnValue = SelfActor->Trace(
+		HitLocation, HitNormal, TraceEnd,
+		TraceStart ? *TraceStart : SelfActor->Location(),
+		bTraceActors ? *bTraceActors : false,
+		Extent ? *Extent : vec3(0, 0, 0),
+		bTraceBSP ? *bTraceBSP : true,
+		BSPTraceFlags ? *BSPTraceFlags : 0);
 }
 
 void NActor::TraceActors(UObject* Self, UObject* BaseClass, UObject*& Actor, vec3& HitLoc, vec3& HitNorm, const vec3& End, std::optional<vec3> Start, std::optional<vec3> Extent)

--- a/SurrealEngine/Native/NActor.h
+++ b/SurrealEngine/Native/NActor.h
@@ -65,6 +65,7 @@ public:
 	static void Subtract_ColorColor(const Color& A, const Color& B, Color& ReturnValue);
 	static void TouchingActors(UObject* Self, UObject* BaseClass, UObject*& Actor);
 	static void Trace(UObject* Self, vec3& HitLocation, vec3& HitNormal, const vec3& TraceEnd, std::optional<vec3> TraceStart, std::optional<bool> bTraceActors, std::optional<vec3> Extent, UObject*& ReturnValue);
+	static void Trace_U227(UObject* Self, vec3& HitLocation, vec3& HitNormal, const vec3& TraceEnd, std::optional<vec3> TraceStart, std::optional<bool> bTraceActors, std::optional<vec3> Extent, std::optional<bool> bTraceBSP, std::optional<uint8_t> BSPTraceFlags, UObject*& ReturnValue);
 	static void TraceActors(UObject* Self, UObject* BaseClass, UObject*& Actor, vec3& HitLoc, vec3& HitNorm, const vec3& End, std::optional<vec3> Start, std::optional<vec3> Extent);
 	static void TraceSurfHitInfo_U227(UObject* Self, vec3& Start, vec3& End, vec3* HitLocation, vec3* HitNormal, UObject* HitTex, int* HitFlags, BitfieldBool& ReturnValue);
 	static void TraceThisActor_U227(UObject* Self, vec3& TraceEnd, vec3& TraceStart, vec3* HitLocation, vec3* HitNormal, std::optional<vec3> Extent, BitfieldBool& ReturnValue);

--- a/SurrealEngine/Native/NCanvas.cpp
+++ b/SurrealEngine/Native/NCanvas.cpp
@@ -39,7 +39,7 @@ void NCanvas::RegisterFunctions()
 		RegisterVMNativeFunc_3("Canvas", "DrawPathNetwork", &NCanvas::DrawPathNetwork_U227, 1754);
 		RegisterVMNativeFunc_5("Canvas", "DrawCircle", &NCanvas::DrawCircle_U227, 1755);
 		RegisterVMNativeFunc_5("Canvas", "DrawBox", &NCanvas::DrawBox_U227, 1756);
-		RegisterVMNativeFunc_2("Canvas", "GetCameraCoords", &NCanvas::GetCameraCoords_U227, 1757);
+		RegisterVMNativeFunc_1("Canvas", "GetCameraCoords", &NCanvas::GetCameraCoords_U227, 1757);
 		RegisterVMNativeFunc_6("Canvas", "SetTile3DOffset", &NCanvas::SetTile3DOffset_U227, 1758);
 		// RegisterVMNativeFunc_5("Canvas", "DrawTris", &NCanvas::DrawTris_U227, 1746);
 		RegisterVMNativeFunc_13("Canvas", "DrawRotatedTile", &NCanvas::DrawRotatedTile_U227, 1747);
@@ -308,8 +308,9 @@ void NCanvas::DrawBox_U227(UObject* Self, Color& Col, int LineFlags, vec3& Start
 
 void NCanvas::GetCameraCoords_U227(UObject* Self, Coords& ReturnValue)
 {
-	LogUnimplemented("Canvas.GetCameraCoords() [U227]");
-	ReturnValue = Coords();
+	Coords c = Coords::InverseRotation(engine->CameraRotation);
+	c.Origin = engine->CameraLocation;
+	ReturnValue = c;
 }
 
 void NCanvas::SetTile3DOffset_U227(UObject* Self, BitfieldBool& bEnable, std::optional<vec3> Offset, std::optional<Rotator> RotOffset, std::optional<bool> bFlatZ, std::optional<float> Scale, std::optional<bool> bWorldOffset)

--- a/SurrealEngine/Native/NLevelInfo.cpp
+++ b/SurrealEngine/Native/NLevelInfo.cpp
@@ -10,6 +10,8 @@ void NLevelInfo::RegisterFunctions()
 	RegisterVMNativeFunc_1("LevelInfo", "GetAddressURL", &NLevelInfo::GetAddressURL, 0);
 	RegisterVMNativeFunc_1("LevelInfo", "GetLocalURL", &NLevelInfo::GetLocalURL, 0);
 	RegisterVMNativeFunc_0("LevelInfo", "InitEventManager", &NLevelInfo::InitEventManager, 650);
+	if (engine->LaunchInfo.IsUnreal1_227())
+		RegisterVMNativeFunc_2("LevelInfo", "GetLocZone", &NLevelInfo::GetLocZone_U227, 1709);
 }
 
 void NLevelInfo::GetAddressURL(UObject* Self, std::string& ReturnValue)
@@ -20,6 +22,11 @@ void NLevelInfo::GetAddressURL(UObject* Self, std::string& ReturnValue)
 void NLevelInfo::GetLocalURL(UObject* Self, std::string& ReturnValue)
 {
 	ReturnValue = UObject::Cast<ULevelInfo>(Self)->URL.ToString();
+}
+
+void NLevelInfo::GetLocZone_U227(UObject* Self, const vec3& Pos, PointRegion& ReturnValue)
+{
+	ReturnValue = UObject::Cast<ULevelInfo>(Self)->GetLocZone(Pos);
 }
 
 void NLevelInfo::InitEventManager(UObject* Self)

--- a/SurrealEngine/Native/NLevelInfo.h
+++ b/SurrealEngine/Native/NLevelInfo.h
@@ -2,6 +2,8 @@
 
 #include "UObject/UObject.h"
 
+struct PointRegion;
+
 class NLevelInfo
 {
 public:
@@ -9,5 +11,6 @@ public:
 
 	static void GetAddressURL(UObject* Self, std::string& ReturnValue);
 	static void GetLocalURL(UObject* Self, std::string& ReturnValue);
+	static void GetLocZone_U227(UObject* Self, const vec3& Pos, PointRegion& ReturnValue);
 	static void InitEventManager(UObject* Self);
 };

--- a/SurrealEngine/Native/NObject.cpp
+++ b/SurrealEngine/Native/NObject.cpp
@@ -230,7 +230,10 @@ void NObject::RegisterFunctions()
 		// RegisterVMNativeFunc_4("Object", "LoadPackageContents", &NObject::LoadPackageContents_U227, 257);
 		RegisterVMNativeFunc_2("Object", "Locs", &NObject::Locs_U227, 238);
 		RegisterVMNativeFunc_5("Object", "MakeColor", &NObject::MakeColor_U227, 198);
-		RegisterVMNativeFunc_5("Object", "MakeQuat", &NObject::MakeQuat_U227, 606);
+		if (engine->LaunchInfo.IsUnreal1_227k())
+			RegisterVMNativeFunc_5("Object", "MakeQuat", &NObject::MakeQuat_U227, 606);
+		else
+			RegisterVMNativeFunc_5("Object", "Quad", &NObject::MakeQuat_U227, 606);
 		RegisterVMNativeFunc_3("Object", "MultiplyEqual_CoordsCoords", &NObject::MultiplyEqual_CoordsCoords_U227, 331);
 		RegisterVMNativeFunc_3("Object", "MultiplyEqual_CoordsRotator", &NObject::MultiplyEqual_CoordsRotator_U227, 332);
 		RegisterVMNativeFunc_3("Object", "MultiplyEqual_QuatFloat", &NObject::MultiplyEqual_QuatFloat_U227, 617);

--- a/SurrealEngine/Native/NPlayerPawn.cpp
+++ b/SurrealEngine/Native/NPlayerPawn.cpp
@@ -31,6 +31,8 @@ void NPlayerPawn::RegisterFunctions()
 		RegisterVMNativeFunc_3("PlayerPawn", "UpdateURL", &NPlayerPawn::UpdateURL, 546);
 	else
 		RegisterVMNativeFunc_1("PlayerPawn", "UpdateURL", &NPlayerPawn::UpdateURL_219, 546);
+	if (engine->LaunchInfo.IsUnreal1_227())
+		RegisterVMNativeFunc_2("PlayerPawn", "IsPressing", &NPlayerPawn::IsPressing_U227, 549);
 }
 
 void NPlayerPawn::ClientTravel(UObject* Self, const std::string& URL, uint8_t TravelType, bool bItems)
@@ -83,6 +85,11 @@ void NPlayerPawn::GetPlayerNetworkAddress(UObject* Self, std::string& ReturnValu
 {
 	LogUnimplemented("PlayerPawn.GetPlayerNetworkAddress");
 	ReturnValue = "";
+}
+
+void NPlayerPawn::IsPressing_U227(UObject* Self, uint8_t& KeyNum, BitfieldBool& ReturnValue)
+{
+	ReturnValue = UObject::Cast<UPlayerPawn>(Self)->IsPressing(KeyNum);
 }
 
 void NPlayerPawn::PasteFromClipboard(UObject* Self, std::string& ReturnValue)

--- a/SurrealEngine/Native/NPlayerPawn.h
+++ b/SurrealEngine/Native/NPlayerPawn.h
@@ -16,6 +16,7 @@ public:
 	static void GetDefaultURL(UObject* Self, const std::string& Option, std::string& ReturnValue);
 	static void GetEntryLevel(UObject* Self, UObject*& ReturnValue);
 	static void GetPlayerNetworkAddress(UObject* Self, std::string& ReturnValue);
+	static void IsPressing_U227(UObject* Self, uint8_t& KeyNum, BitfieldBool& ReturnValue);
 	static void PasteFromClipboard(UObject* Self, std::string& ReturnValue);
 	static void ResetKeyboard(UObject* Self);
 	static void UpdateURL(UObject* Self, const std::string& NewOption, const std::string& NewValue, bool bSaveDefault);

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -1446,6 +1446,31 @@ UObject* UActor::Trace(vec3& hitLocation, vec3& hitNormal, const vec3& traceEnd,
 	return hit.Actor;
 }
 
+UObject* UActor::Trace(vec3& hitLocation, vec3& hitNormal, const vec3& traceEnd, const vec3& traceStart, bool bTraceActors, const vec3& extent, bool bTraceBSP, uint8_t BSPTraceFlags)
+{
+	LogUnimplemented("Actor.Trace() [U227 - BSPTraceFlags parameter isn't implemented");
+	TraceFlags flags;
+	flags.movers = true;
+	flags.world = bTraceBSP;
+	if (bTraceActors)
+	{
+		flags.pawns = true;
+		flags.others = true;
+		flags.onlyProjectiles = true;
+	}
+
+	// hack?
+	if (IsA("ChallengeHUD"))
+	{
+		flags.zoneChanges = true;
+	}
+
+	CollisionHit hit = XLevel()->Collision.TraceFirstHit(traceStart, traceEnd, this, extent, flags);
+	hitNormal = hit.Normal;
+	hitLocation = traceStart + (traceEnd - traceStart) * hit.Fraction;
+	return hit.Actor;
+}
+
 bool UActor::FastTrace(const vec3& traceEnd, const vec3& traceStart)
 {
 	return !XLevel()->Collision.TraceAnyHit(traceStart, traceEnd, this, false, true, false);
@@ -3694,6 +3719,17 @@ float UPawn::GetSpeed()
 
 /////////////////////////////////////////////////////////////////////////////
 
+bool UPlayerPawn::IsPressing(uint8_t KeyNum)
+{
+	for (auto& activeButtons : engine->activeInputButtons)
+	{
+		if (activeButtons.second == KeyNum)
+			return true;
+	}
+
+	return false;
+}
+
 void UPlayerPawn::PausedInput(float elapsed)
 {
 	if (Role() >= ROLE_SimulatedProxy && Player() && !UObject::TryCast<UCamera>(this))
@@ -3805,6 +3841,12 @@ void ULevelInfo::UpdateActorZone()
 {
 	// No zone events are sent by LevelInfo actors
 	Region() = FindRegion();
+}
+
+PointRegion ULevelInfo::GetLocZone(const vec3& pos)
+{
+	//return XLevel()->Model->FindRegion(pos, Level());
+	return {};
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -3845,8 +3845,7 @@ void ULevelInfo::UpdateActorZone()
 
 PointRegion ULevelInfo::GetLocZone(const vec3& pos)
 {
-	//return XLevel()->Model->FindRegion(pos, Level());
-	return {};
+	return XLevel()->Model->FindRegion(pos, Level());
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -414,6 +414,8 @@ public:
 	bool SetCollisionSize(float newRadius, float newHeight);
 
 	UObject* Trace(vec3& hitLocation, vec3& hitNormal, const vec3& traceEnd, const vec3& traceStart, bool bTraceActors, const vec3& extent);
+	// Unreal 227's version of Actor.Trace()
+	UObject* Trace(vec3& hitLocation, vec3& hitNormal, const vec3& traceEnd, const vec3& traceStart, bool bTraceActors, const vec3& extent, bool bTraceBSP, uint8_t	BSPTraceFlags);
 	bool FastTrace(const vec3& traceEnd, const vec3& traceStart);
 	// Unreal 227 - Trace against world and return the wanted information (location, normal, texture and/or polyflags)
 	bool TraceSurfHitInfo(vec3& Start, vec3& End, vec3* HitLocation, vec3* HitNormal, UTexture* HitTex, int* HitFlags);
@@ -1448,6 +1450,9 @@ public:
 
 	void UpdateActorZone() override;
 
+	// Unreal 227 addition
+	PointRegion GetLocZone(const vec3& pos);
+
 	UnrealURL URL;
 
 	FixedArrayView<int, 8> AIProfile() { return FixedArray<int, 8>(PropOffsets_LevelInfo.AIProfile); }
@@ -1988,6 +1993,9 @@ public:
 
 	void Tick(float elapsed) override;
 	void TickRotating(float elapsed) override;
+
+	// Unreal 227 addition
+	bool IsPressing(uint8_t KeyNum);
 
 	float& AppliedBob() { return Value<float>(PropOffsets_PlayerPawn.AppliedBob); }
 	float& Bob() { return Value<float>(PropOffsets_PlayerPawn.Bob); }

--- a/SurrealEngine/VM/ExpressionValue.h
+++ b/SurrealEngine/VM/ExpressionValue.h
@@ -119,7 +119,21 @@ public:
 	const Coords& ToCoords() const;
 	const quaternion& ToQuat() const;
 
-	template<typename T> T ToType() = delete;
+	template<typename T> T ToType()
+	{
+		if constexpr (std::is_reference_v<T>)
+		{
+			CheckType(ExpressionValueType::ValueStruct);
+			if (!VariableProperty)
+				return *static_cast<std::remove_cvref_t<T>*>(GetStructValue()->Ptr);
+			else
+				return *static_cast<std::remove_cvref_t<T>*>(Ptr);
+		}
+		else
+		{
+			return {};
+		}
+	}
 
 	void Store(const ExpressionValue& rvalue);
 	void Load();


### PR DESCRIPTION
(Yeah I'm running out of titles to come up with)
- Implement the following Unreal 227 functions:
  - `Actor.Trace()`, with the exception of `BSPTraceFlags` parameter
  - `PlayerPawn.IsPressing()`
  - `LevelInfo.GetLocZone()`... kinda. I dunno if it actually works
  - `Canvas.GetCameraCoords()`
  - `Object.Quad()` which is just what `Object.MakeQuat()` from 227k is called in 227i
- `ExpressionValue::ToType()` handles structs by default

All this gets us is.... 227i crashing when you fire a hitscan weapon, instead of it not working at all. :V
Oh, and the playernames appear once again in multiplayer/botmatches