### PR TITLE
Fix LevelInfo.GetLocZone() crashes and add more stubs for 227

### DIFF
--- a/SurrealEngine/Native/NActor.cpp
+++ b/SurrealEngine/Native/NActor.cpp
@@ -84,8 +84,8 @@ void NActor::RegisterFunctions()
 	RegisterVMNativeFunc_1("Actor", "Sleep", &NActor::Sleep, 256);
 	RegisterLatentAction(257, LatentRunState::Sleep);
 	RegisterVMNativeFunc_6("Actor", "Spawn", &NActor::Spawn, 278);
-	if (!engine->LaunchInfo.IsUnreal1())
-		RegisterVMNativeFunc_3("Actor", "Subtract_ColorColor", &NActor::Subtract_ColorColor, 549); // U227 reserves this slot for PlayerPawn.IsPressing()
+	if (!engine->LaunchInfo.IsUnreal1() || engine->LaunchInfo.IsUnreal1_227k())
+		RegisterVMNativeFunc_3("Actor", "Subtract_ColorColor", &NActor::Subtract_ColorColor, 549); // Pre-j versions of U227 reserves this slot for PlayerPawn.IsPressing()
 	RegisterVMNativeFunc_2("Actor", "TouchingActors", &NActor::TouchingActors, 307);
 	if (engine->LaunchInfo.IsUnreal1_227())
 		RegisterVMNativeFunc_9("Actor", "Trace", &NActor::Trace_U227, 277);

--- a/SurrealEngine/Native/NLevelInfo.cpp
+++ b/SurrealEngine/Native/NLevelInfo.cpp
@@ -11,7 +11,22 @@ void NLevelInfo::RegisterFunctions()
 	RegisterVMNativeFunc_1("LevelInfo", "GetLocalURL", &NLevelInfo::GetLocalURL, 0);
 	RegisterVMNativeFunc_0("LevelInfo", "InitEventManager", &NLevelInfo::InitEventManager, 650);
 	if (engine->LaunchInfo.IsUnreal1_227())
-		RegisterVMNativeFunc_2("LevelInfo", "GetLocZone", &NLevelInfo::GetLocZone_U227, 1709);
+	{
+		RegisterVMNativeFunc_3("LevelInfo", "GetLocZone", &NLevelInfo::GetLocZone_U227, 1709);
+		RegisterVMNativeFunc_3("LevelInfo", "AllocateObj", &NLevelInfo::AllocateObj_U227, 1710);
+		RegisterVMNativeFunc_2("LevelInfo", "FreeObject", &NLevelInfo::FreeObject_U227, 1711);
+	}
+}
+
+void NLevelInfo::AllocateObj_U227(UObject* Self, UObject* ObjClass, UObject*& ReturnValue)
+{
+	LogUnimplemented("LevelInfo.AllocateObj() [U227]");
+	ReturnValue = nullptr;
+}
+
+void NLevelInfo::FreeObject_U227(UObject* Self, UObject* Obj)
+{
+	LogUnimplemented("LevelInfo.FreeObject() [U227]");
 }
 
 void NLevelInfo::GetAddressURL(UObject* Self, std::string& ReturnValue)

--- a/SurrealEngine/Native/NLevelInfo.h
+++ b/SurrealEngine/Native/NLevelInfo.h
@@ -9,6 +9,8 @@ class NLevelInfo
 public:
 	static void RegisterFunctions();
 
+	static void AllocateObj_U227(UObject* Self, UObject* ObjClass, UObject*& ReturnValue);
+	static void FreeObject_U227(UObject* Self, UObject* Obj);
 	static void GetAddressURL(UObject* Self, std::string& ReturnValue);
 	static void GetLocalURL(UObject* Self, std::string& ReturnValue);
 	static void GetLocZone_U227(UObject* Self, const vec3& Pos, PointRegion& ReturnValue);

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -104,6 +104,7 @@ PackageManager::PackageManager(const GameLaunchInfo& launchInfo) : launchInfo(la
 	CreateTransientPackage();
 	RegisterFunctions();
 	LoadEngineIniFiles();
+	LoadFileExtensions();
 	LoadIntFiles();
 	LoadPackageRemaps();
 	ScanPaths();
@@ -270,8 +271,6 @@ void PackageManager::ScanPaths()
 	{
 		paths = GetIniValues("system", "Core.System", "Paths");
 	}
-	mapExtension = GetIniValue("System", "URL", "MapExt");
-	saveExtension = GetIniValue("System", "URL", "SaveExt");
 
 	// Handle SavePath and CachePath
 	const auto savePath = convert_path_separators(GetIniValue("System", "Core.System", "SavePath"));
@@ -279,6 +278,25 @@ void PackageManager::ScanPaths()
 
 	const auto cachePath = convert_path_separators(GetIniValue("System", "Core.System", "CachePath"));
 	gameCacheFolderPath = (gameSystemFolderPath / cachePath).lexically_normal();
+
+	// Unreal 227j+ and UT 469d+ store localization files in SystemLocalized folder
+	if ((IsUnreal1_227() && launchInfo.engineSubVersion >= 10) || (IsUnrealTournament_469() && launchInfo.engineSubVersion >= 4))
+	{
+		auto langpaths = GetIniValues("System", "Core.System", "LangPaths");
+
+		// Substitute <lang> with the actual language extension
+		for (auto& langpath : langpaths)
+		{
+			auto pos = langpath.find("<lang>");
+			while (pos != std::string::npos)
+			{
+				langpath.replace(pos, 6, languageExtension);
+				pos = langpath.find("<lang>");
+			}
+
+			paths.push_back(langpath);
+		}
+	}
 
 	for (auto& currentPathStr: paths)
 	{
@@ -624,6 +642,15 @@ void PackageManager::LoadEngineIniFiles()
 		iniFiles["User"] = std::make_unique<IniFile>((gameSystemFolderPath / userIniName).string());
 		defaultUserFile = std::make_unique<IniFile>((gameSystemFolderPath / "DefUser.ini").string());
 	}
+}
+
+void PackageManager::LoadFileExtensions()
+{
+	const auto systemIni = GetSystemIniFile();
+
+	mapExtension = systemIni->GetValue("URL", "MapExt", "unr");
+	saveExtension = systemIni->GetValue("URL", "SaveExt", "usa");
+	languageExtension = systemIni->GetValue("Engine.Engine", "Language", "int");
 }
 
 void PackageManager::LoadIntFiles()
@@ -1044,6 +1071,9 @@ void PackageManager::RegisterNativeClasses()
 
 	if (IsUnreal1_227())
 	{
+		RegisterNativeClass<UInventoryAttachment>(enginePackage, "InventoryAttachment", "Actor");
+		RegisterNativeClass<UWeaponAttachment>(enginePackage, "WeaponAttachment", "InventoryAttachment");
+		RegisterNativeClass<UWeaponMuzzleFlash>(enginePackage, "WeaponMuzzleFlash", "InventoryAttachment");
 		RegisterNativeClass<U227Projector>(enginePackage, "Projector", "Actor");
 		RegisterNativeClass<UDynamicZoneInfo>(enginePackage, "DynamicZoneInfo", "ZoneInfo");
 		RegisterNativeClass<UDistantLightActor>(emitterPackage, "DistantLightActor", "Light");

--- a/SurrealEngine/Package/PackageManager.h
+++ b/SurrealEngine/Package/PackageManager.h
@@ -106,6 +106,7 @@ private:
 	std::unique_ptr<IniFile>& LoadUserIniFile();
 	std::unique_ptr<IniFile>& LoadSystemIniFile();
 	void LoadEngineIniFiles();
+	void LoadFileExtensions();
 	void LoadIntFiles();
 	void LoadPackageRemaps();
 	std::map<NameString, std::string> ParseIntPublicValue(const std::string& value);
@@ -154,6 +155,7 @@ private:
 
 	std::string mapExtension;
 	std::string saveExtension;
+	std::string languageExtension;
 
 	bool missing_se_system_ini = false;
 

--- a/SurrealEngine/UObject/PropertyOffsets.cpp
+++ b/SurrealEngine/UObject/PropertyOffsets.cpp
@@ -5315,6 +5315,40 @@ void InitPropertyOffsets_Projector(PackageManager* packages)
 	PropOffsets_Projector.bProjecting = cls->GetPropertyDataOffset("bProjecting");
 }
 
+PropertyDataOffsets_WeaponMuzzleFlash PropOffsets_WeaponMuzzleFlash;
+
+static void InitPropertyOffsets_WeaponMuzzleFlash(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Engine")->GetUObject("Class", "WeaponMuzzleFlash"));
+	if (!cls)
+	{
+		memset(&PropOffsets_WeaponMuzzleFlash, 0xff, sizeof(PropOffsets_WeaponMuzzleFlash));
+		return;
+	}
+
+	PropOffsets_WeaponMuzzleFlash.bConstantMuzzle = cls->GetPropertyDataOffset("bConstantMuzzle");
+	PropOffsets_WeaponMuzzleFlash.bCurrentlyVisible = cls->GetPropertyDataOffset("bCurrentlyVisible");
+	PropOffsets_WeaponMuzzleFlash.bFlashTimer = cls->GetPropertyDataOffset("bFlashTimer");
+	PropOffsets_WeaponMuzzleFlash.bStrobeMuzzle = cls->GetPropertyDataOffset("bStrobeMuzzle");
+}
+
+PropertyDataOffsets_WeaponAttachment PropOffsets_WeaponAttachment;
+
+static void InitPropertyOffsets_WeaponAttachment(PackageManager* packages)
+{
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("Engine")->GetUObject("Class", "WeaponAttachment"));
+	if (!cls)
+	{
+		memset(&PropOffsets_WeaponAttachment, 0xff, sizeof(PropOffsets_WeaponAttachment));
+		return;
+	}
+
+	PropOffsets_WeaponAttachment.bCopyDisplay = cls->GetPropertyDataOffset("bCopyDisplay");
+	PropOffsets_WeaponAttachment.LastUpdateTime = cls->GetPropertyDataOffset("LastUpdateTime");
+	PropOffsets_WeaponAttachment.MyMuzzleFlash = cls->GetPropertyDataOffset("MyMuzzleFlash");
+	PropOffsets_WeaponAttachment.WeaponOwner = cls->GetPropertyDataOffset("WeaponOwner");
+}
+
 //////////////////////////////////////////
 
 void InitPropertyOffsets(PackageManager* packages)
@@ -5404,6 +5438,8 @@ void InitPropertyOffsets(PackageManager* packages)
 	}
 	if (packages->IsUnreal1_227())
 	{
+		InitPropertyOffsets_WeaponMuzzleFlash(packages);
+		InitPropertyOffsets_WeaponAttachment(packages);
 		InitPropertyOffsets_DistantLightActor(packages);
 		InitPropertyOffsets_XParticleEmitter(packages);
 		InitPropertyOffsets_XParticleForces(packages);

--- a/SurrealEngine/UObject/PropertyOffsets.h
+++ b/SurrealEngine/UObject/PropertyOffsets.h
@@ -4243,3 +4243,23 @@ struct PropertyDataOffsets_Projector
 };
 
 extern PropertyDataOffsets_Projector PropOffsets_Projector;
+
+struct PropertyDataOffsets_WeaponMuzzleFlash
+{
+	PropertyDataOffset bConstantMuzzle;
+	PropertyDataOffset bStrobeMuzzle;
+	PropertyDataOffset bFlashTimer;
+	PropertyDataOffset bCurrentlyVisible;
+};
+
+extern PropertyDataOffsets_WeaponMuzzleFlash PropOffsets_WeaponMuzzleFlash;
+
+struct PropertyDataOffsets_WeaponAttachment
+{
+	PropertyDataOffset bCopyDisplay;
+	PropertyDataOffset WeaponOwner;
+	PropertyDataOffset MyMuzzleFlash;
+	PropertyDataOffset LastUpdateTime;
+};
+
+extern PropertyDataOffsets_WeaponAttachment PropOffsets_WeaponAttachment;

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -850,6 +850,13 @@ public:
 	UInventorySpot*& myMarker() { return Value<UInventorySpot*>(PropOffsets_Inventory.myMarker); }
 };
 
+class UInventoryAttachment : public UActor
+{
+public:
+	using UActor::UActor;
+	// Empty base class
+};
+
 class UWeapon : public UInventory
 {
 public:
@@ -917,6 +924,28 @@ public:
 	float& shakemag() { return Value<float>(PropOffsets_Weapon.shakemag); }
 	float& shaketime() { return Value<float>(PropOffsets_Weapon.shaketime); }
 	float& shakevert() { return Value<float>(PropOffsets_Weapon.shakevert); }
+};
+
+class UWeaponMuzzleFlash : public UInventoryAttachment
+{
+public:
+	using UInventoryAttachment::UInventoryAttachment;
+
+	BitfieldBool bConstantMuzzle() { return BoolValue(PropOffsets_WeaponMuzzleFlash.bConstantMuzzle); }
+	BitfieldBool bStrobeMuzzle() { return BoolValue(PropOffsets_WeaponMuzzleFlash.bStrobeMuzzle); }
+	BitfieldBool bFlashTimer() { return BoolValue(PropOffsets_WeaponMuzzleFlash.bFlashTimer); }
+	BitfieldBool bCurrentlyVisible() { return BoolValue(PropOffsets_WeaponMuzzleFlash.bCurrentlyVisible); }
+};
+
+class UWeaponAttachment : public UInventoryAttachment
+{
+public:
+	using UInventoryAttachment::UInventoryAttachment;
+
+	BitfieldBool bCopyDisplay() { return BoolValue(PropOffsets_WeaponAttachment.bCopyDisplay); }
+	float& LastUpdateTime() { return Value<float>(PropOffsets_WeaponAttachment.LastUpdateTime); }
+	UWeaponMuzzleFlash*& MyMuzzleFlash() { return Value<UWeaponMuzzleFlash*>(PropOffsets_WeaponAttachment.MyMuzzleFlash); }
+	UWeapon*& WeaponOwner() { return Value<UWeapon*>(PropOffsets_WeaponAttachment.WeaponOwner); }
 };
 
 class UNavigationPoint : public UActor


### PR DESCRIPTION
LevelInfo.GetLocZone()'s registration is fixed, firing hitscan weapons don't cause crashes anymore.

Stubs for the following classes/functions are added:
- InventoryAttachment
- WeaponAttachment
- WeaponMuzzleFlash
- LevelInfo.AllocateObj()
- LevelInfo.FreeObject()

There are also some small changes to the PackageManager, namely:
- It stores the language extension (.int, .est, etc.)
- It tries to load localization files from the `LangPaths` variables if there are any (isn't really tested because 227k and 469d don't work yet)