### PR TITLE
Fix infinite recursion and allow ogg looping

### DIFF
--- a/SurrealEngine/Audio/AudioSource.cpp
+++ b/SurrealEngine/Audio/AudioSource.cpp
@@ -316,8 +316,9 @@ public:
 class OggAudioSource : public AudioSource
 {
 public:
-	OggAudioSource(Array<uint8_t> input) : filedata(std::move(input))
+	OggAudioSource(Array<uint8_t> input, bool loop) : filedata(std::move(input))
 	{
+		bIsLooped = loop;
 		int error = 0;
 		handle = stb_vorbis_open_pushdata(filedata.data(), (int)filedata.size(), &stream_byte_offset, &error, nullptr);
 		if (!handle)
@@ -405,6 +406,9 @@ public:
 			pcm_position += samples;
 			data_left -= samples;
 		}
+
+		if (stream_eof && bIsLooped)
+			SeekToSample(0);
 
 		return (data_requested - data_left) * stream_info.channels;
 	}
@@ -497,9 +501,9 @@ std::unique_ptr<AudioSource> AudioSource::CreateWav(Array<uint8_t> filedata)
 	return std::make_unique<WavAudioSource>(std::move(filedata));
 }
 
-std::unique_ptr<AudioSource> AudioSource::CreateOgg(Array<uint8_t> filedata)
+std::unique_ptr<AudioSource> AudioSource::CreateOgg(Array<uint8_t> filedata, bool loop)
 {
-	return std::make_unique<OggAudioSource>(std::move(filedata));
+	return std::make_unique<OggAudioSource>(std::move(filedata), loop);
 }
 
 std::unique_ptr<AudioSource> AudioSource::CreateMod(Array<uint8_t> filedata, bool loop, int subsong)

--- a/SurrealEngine/Audio/AudioSource.h
+++ b/SurrealEngine/Audio/AudioSource.h
@@ -10,7 +10,7 @@ public:
 	static std::unique_ptr<AudioSource> CreateMp3(Array<uint8_t> filedata);
 	static std::unique_ptr<AudioSource> CreateFlac(Array<uint8_t> filedata);
 	static std::unique_ptr<AudioSource> CreateWav(Array<uint8_t> filedata);
-	static std::unique_ptr<AudioSource> CreateOgg(Array<uint8_t> filedata);
+	static std::unique_ptr<AudioSource> CreateOgg(Array<uint8_t> filedata, bool loop = false);
 	static std::unique_ptr<AudioSource> CreateMod(Array<uint8_t> filedata, bool loop = true, int subsong = 0);
 	static std::unique_ptr<AudioSource> CreateResampler(int targetFrequency, std::unique_ptr<AudioSource> source);
 

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -3115,9 +3115,13 @@ UActor* UPawn::PathSpecialHandling(const Array<UNavigationPoint*>& bestPath)
 #if 0
 	return SetRouteCache(bestPath);
 #else
+	IsInPathSpecialHandling = true;
 	UActor* oldBestPoint = SetRouteCache(bestPath);
 	if (!oldBestPoint)
+	{
+		IsInPathSpecialHandling = false;
 		return nullptr;
+	}
 
 	UActor* bestPoint = oldBestPoint;
 
@@ -3142,6 +3146,7 @@ UActor* UPawn::PathSpecialHandling(const Array<UNavigationPoint*>& bestPath)
 			SpecialGoal() = nullptr;
 	}
 
+	IsInPathSpecialHandling = false;
 	return bestPoint;
 #endif
 }
@@ -3390,7 +3395,9 @@ UObject* UPawn::FindPathToward(UObject* anActor, bool singlePath)
 	{
 		if (!MarkReachableNavEndPoints())
 			return SetRouteCache({});
-		return PathSpecialHandling(FindPathToEndPoint(aNavPoint, 1000).first);
+		if (!IsInPathSpecialHandling)
+			return PathSpecialHandling(FindPathToEndPoint(aNavPoint, 1000).first);
+		return SetRouteCache({});
 	}
 	else if (auto actor = UObject::TryCast<UActor>(anActor))
 	{

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -2070,6 +2070,9 @@ public:
 	float& SmellThreshold() { return Value<float>(PropOffsets_Pawn.SmellThreshold); }
 	NameString Alliance() { return Value<NameString>(PropOffsets_Pawn.Alliance);}
 	Rotator& AIAddViewRotation() { return Value<Rotator>(PropOffsets_Pawn.AIAddViewRotation); }
+
+private:
+	bool IsInPathSpecialHandling = false;
 };
 
 class UScout : public UPawn

--- a/SurrealEngine/UObject/USubsystem.cpp
+++ b/SurrealEngine/UObject/USubsystem.cpp
@@ -371,7 +371,7 @@ void USurrealAudioDevice::UpdateMusic()
 			if (CurrentSong->Format == "mp3")
 				source = AudioSource::CreateMp3(CurrentSong->Data);
 			else if (CurrentSong->Format == "ogg" || CurrentSong->Format == "event") // Some ogg files in Unreal 227 have event as format for some reason
-				source = AudioSource::CreateOgg(CurrentSong->Data);
+				source = AudioSource::CreateOgg(CurrentSong->Data, true);
 			else if (CurrentSong->Format == "wav")
 				source = AudioSource::CreateWav(CurrentSong->Data);
 			else


### PR DESCRIPTION
- Fix infinite recursion that's happening between `UPawn::PathSpecialHandling()` and `UPawn::FindPathToward()`
- Support song looping in .ogg files