### PR TITLE
Get Unreal Tournament 469c to boot

### DIFF
--- a/Docs/Status.md
+++ b/Docs/Status.md
@@ -45,7 +45,6 @@ they end up dying because SE thinks that they've fallen from a great height.
 * viewclass command crashes with null deref.
 * Sometimes opening a map crashes the engine with a "Failed to spawn the player actor" error.
 * Sounds may become too loud (e.g. Pulse Rifle secondary fire, minigun firing sound)
-* Third person weapon meshes do not get rendered.
 * Inventory from loaded saves do NOT transfer to the next map.
 * Saving packages (.u[xx] files, game saves, etc.) functionality is not fully implemented yet.
 * There is no OpenGL renderer.
@@ -75,6 +74,10 @@ they end up dying because SE thinks that they've fallen from a great height.
 ## Unreal Tournament
 
 436 version of the game launches. Menu options will work and botmatches can be played. Bots will behave more or less like they do in Unreal and some maps might have some functionality missing.
+
+469c version of the game also launches. So far the touch events doesn't work.
+
+Anything beyond 469c currently won't boot.
 
 ### Known bugs:
 * [469*] Many new native functions/features are not yet implemented.

--- a/SurrealEngine/Native/NCanvas.cpp
+++ b/SurrealEngine/Native/NCanvas.cpp
@@ -53,6 +53,11 @@ void NCanvas::RegisterFunctions()
 		RegisterVMNativeFunc_1("Canvas", "ClearCustomLightSources", &NCanvas::ClearCustomLightSources_U227, 1776);
 		RegisterVMNativeFunc_1("Canvas", "Reset", &NCanvas::Reset_U227, 0);
 	}
+	if (engine->LaunchInfo.IsUnrealTournament_469())
+	{
+		RegisterVMNativeFunc_9("Canvas", "CreateFont", &NCanvas::CreateFont_UT469, 0);
+		RegisterVMNativeFunc_1("Canvas", "GetDesktopDPI", &NCanvas::GetDesktopDPI_UT469, 0);
+	}
 }
 
 void NCanvas::DrawActor(UObject* Self, UObject* A, bool WireFrame, std::optional<bool> ClearZ)
@@ -369,4 +374,15 @@ void NCanvas::ClearCustomLightSources_U227(UObject* Self)
 void NCanvas::Reset_U227(UObject* Self)
 {
 	LogUnimplemented("Canvas.Reset() [U227]");
+}
+
+void NCanvas::CreateFont_UT469(UObject* Self, uint8_t Font, int Size, bool Bold, bool Italic, bool Underlined, bool DPIScaled, bool Antialiased, UObject*& ReturnValue)
+{
+	LogUnimplemented("Canvas.CreateFont() [UT469]");
+	ReturnValue = nullptr;
+}
+
+void NCanvas::GetDesktopDPI_UT469(UObject* Self, int& ReturnValue)
+{
+	ReturnValue = static_cast<int>(engine->window->GetDpiScale() * 96.0);
 }

--- a/SurrealEngine/Native/NCanvas.h
+++ b/SurrealEngine/Native/NCanvas.h
@@ -42,4 +42,8 @@ public:
 	static void AddCustomLightSource_U227(UObject* Self, vec3& Pos, std::optional<Rotator> Dir, std::optional<bool> bDefault);
 	static void ClearCustomLightSources_U227(UObject* Self);
 	static void Reset_U227(UObject* Self);
+
+	// UT469 additions
+	static void CreateFont_UT469(UObject* Self, uint8_t Font, int Size, bool Bold, bool Italic, bool Underlined, bool DPIScaled, bool Antialiased, UObject*& ReturnValue);
+	static void GetDesktopDPI_UT469(UObject* Self, int& ReturnValue);
 };

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -202,9 +202,19 @@ bool UActor::Destroy()
 
 	CallEvent(this, EventName::Destroyed);
 
-	for (const auto actor : Touching())
-		if (actor)
-			UnTouch(actor);
+	if (engine->LaunchInfo.IsUnrealTournament_469())
+	{
+		for (const auto actor : Touching_UT469())
+			if (actor)
+				UnTouch(actor);
+	}
+	else
+	{
+		for (const auto actor : Touching())
+			if (actor)
+				UnTouch(actor);
+	}
+
 
 	SetOwner(nullptr);
 
@@ -1368,10 +1378,21 @@ bool UActor::SetLocation(const vec3& newLocation)
 		}
 
 		// Untouch everything we aren't overlapping anymore
-		for (const auto actor : Touching())
+		if (engine->LaunchInfo.IsUnrealTournament_469())
 		{
-			if (actor && !IsOverlapping(actor))
-				UnTouch(actor);
+			for (const auto actor : Touching_UT469())
+			{
+				if (actor && !IsOverlapping(actor))
+					UnTouch(actor);
+			}
+		}
+		else
+		{
+			for (const auto actor : Touching())
+			{
+				if (actor && !IsOverlapping(actor))
+					UnTouch(actor);
+			}
 		}
 	}
 
@@ -1704,9 +1725,18 @@ CollisionHit UActor::TryMove(const vec3& delta, bool dryRun, bool isOwnBaseBlock
 	}
 
 	// Untouch everything we aren't overlapping anymore
-	for (const auto actor : Touching())
-		if (actor && !IsOverlapping(actor))
-			UnTouch(actor);
+	if (engine->LaunchInfo.IsUnrealTournament_469())
+	{
+		for (const auto actor : Touching_UT469())
+			if (actor && !IsOverlapping(actor))
+				UnTouch(actor);
+	}
+	else
+	{
+		for (const auto actor : Touching())
+			if (actor && !IsOverlapping(actor))
+				UnTouch(actor);
+	}
 
 	UpdateActorZone();
 
@@ -1736,47 +1766,97 @@ void UActor::Touch(UActor* actor)
 	if (bDeleteMe() || actor->bDeleteMe())
 		return;
 
-	auto TouchingArray = Touching();
-	auto TouchingArray2 = actor->Touching();
-
-	// Do nothing if actors are already touching
-	for (int i = 0; i < TouchingArraySize; i++)
+	if (engine->LaunchInfo.IsUnrealTournament_469())
 	{
-		if (TouchingArray[i] == actor)
+		auto TouchingArray = Touching_UT469();
+		auto TouchingArray2 = actor->Touching_UT469();
+
+		// Do nothing if actors are already touching
+		for (int i = 0; i < TouchingArray.size(); i++)
+		{
+			if (TouchingArray[i] == actor)
+				return;
+		}
+
+		// Only setup touch if we have room in both arrays
+		int slot1 = -1, slot2 = -1;
+		for (int i = 0; i < TouchingArray.size(); i++)
+		{
+			if (slot1 == -1 && TouchingArray[i] == nullptr)
+				slot1 = i;
+			if (slot2 == -1 && TouchingArray2[i] == nullptr)
+				slot2 = i;
+		}
+		if (slot1 == -1 || slot2 == -1)
 			return;
+
+		// Setup links first so Destroy or recursive Touch calls always finds the touch binding
+		TouchingArray[slot1] = actor;
+		TouchEventSent[slot1] = true;
+		TouchingArray2[slot2] = this;
+		actor->TouchEventSent[slot2] = false;
+
+		// Notify unrealscript for first actor
+		CallEvent(this, EventName::Touch, { ExpressionValue::ObjectValue(actor) });
+
+		// Notify unrealscript for second actor
+		if (!actor->bDeleteMe())
+		{
+			for (int i = 0; i < TouchingArray.size(); i++)
+			{
+				if (TouchingArray2[i] == this && !actor->TouchEventSent[i])
+				{
+					actor->TouchEventSent[i] = true;
+					CallEvent(actor, EventName::Touch, { ExpressionValue::ObjectValue(this) });
+					break;
+				}
+			}
+		}
 	}
-
-	// Only setup touch if we have room in both arrays
-	int slot1 = -1, slot2 = -1;
-	for (int i = 0; i < TouchingArraySize; i++)
+	else
 	{
-		if (slot1 == -1 && TouchingArray[i] == nullptr)
-			slot1 = i;
-		if (slot2 == -1 && TouchingArray2[i] == nullptr)
-			slot2 = i;
-	}
-	if (slot1 == -1 || slot2 == -1)
-		return;
+		auto TouchingArray = Touching();
+		auto TouchingArray2 = actor->Touching();
 
-	// Setup links first so Destroy or recursive Touch calls always finds the touch binding
-	TouchingArray[slot1] = actor;
-	TouchEventSent[slot1] = true;
-	TouchingArray2[slot2] = this;
-	actor->TouchEventSent[slot2] = false;
-
-	// Notify unrealscript for first actor
-	CallEvent(this, EventName::Touch, { ExpressionValue::ObjectValue(actor) });
-
-	// Notify unrealscript for second actor
-	if (!actor->bDeleteMe())
-	{
+		// Do nothing if actors are already touching
 		for (int i = 0; i < TouchingArraySize; i++)
 		{
-			if (TouchingArray2[i] == this && !actor->TouchEventSent[i])
+			if (TouchingArray[i] == actor)
+				return;
+		}
+
+		// Only setup touch if we have room in both arrays
+		int slot1 = -1, slot2 = -1;
+		for (int i = 0; i < TouchingArraySize; i++)
+		{
+			if (slot1 == -1 && TouchingArray[i] == nullptr)
+				slot1 = i;
+			if (slot2 == -1 && TouchingArray2[i] == nullptr)
+				slot2 = i;
+		}
+		if (slot1 == -1 || slot2 == -1)
+			return;
+
+		// Setup links first so Destroy or recursive Touch calls always finds the touch binding
+		TouchingArray[slot1] = actor;
+		TouchEventSent[slot1] = true;
+		TouchingArray2[slot2] = this;
+		actor->TouchEventSent[slot2] = false;
+
+		// Notify unrealscript for first actor
+		CallEvent(this, EventName::Touch, { ExpressionValue::ObjectValue(actor) });
+
+		// Notify unrealscript for second actor
+		if (!actor->bDeleteMe())
+		{
+			for (int i = 0; i < TouchingArraySize; i++)
 			{
-				actor->TouchEventSent[i] = true;
-				CallEvent(actor, EventName::Touch, { ExpressionValue::ObjectValue(this) });
-				break;
+				if (TouchingArray2[i] == this && !actor->TouchEventSent[i])
+				{
+					actor->TouchEventSent[i] = true;
+					CallEvent(actor, EventName::Touch, { ExpressionValue::ObjectValue(this) });
+					break;
+				}
 			}
 		}
 	}

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -386,6 +386,15 @@ struct sAnimNotify
 	float CallKey;
 };
 
+// UT 469
+enum FontFamily
+{
+	FF_Arial,	// Arial on Windows, Helvetica on Linux/Mac
+	FF_Times,	// Times New Roman on Windows, times on Linux/Mac
+	FF_Courier, // Courier New on Windows, courier on Linux/Mac
+	FF_Tahoma   // Standard UWindow font, Linux/Mac will use Verdana if requested.
+};
+
 class UActor : public UObject
 {
 public:

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -640,6 +640,7 @@ public:
 	float& TimerCounter() { return Value<float>(PropOffsets_Actor.TimerCounter); }
 	float& TimerRate() { return Value<float>(PropOffsets_Actor.TimerRate); }
 	FixedArrayView<UActor*, 4> Touching() { return FixedArray<UActor*, 4>(PropOffsets_Actor.Touching); }
+	TypedScriptArray<UActor*> Touching_UT469() { return DynamicArray<UActor*>(PropOffsets_Actor.Touching); }
 	float& TransientSoundRadius() { return Value<float>(PropOffsets_Actor.TransientSoundRadius); }
 	float& TransientSoundVolume() { return Value<float>(PropOffsets_Actor.TransientSoundVolume); }
 	float& TweenRate() { return Value<float>(PropOffsets_Actor.TweenRate); }


### PR DESCRIPTION
The work necessary was pretty minimal.
Implemented `Canvas.GetDesktopDPI()` while `Canvas.CreateFont()` remains a stub for now.

The bigger change is to `Actor.Touching` property. It has been changed from a static array to dynamic-ish array that behaves like a static array. This means that Touch/Untouch codepaths had to be split in two: One specifically for UT469, the other for the rest.

(Technically 227 has its own `RealTouching` property but 227 currently works fine without handling it)

These changes gets 469c to boot up, but currently touch events do not work.