### PR TITLE
Add stubs for RMusicPlayer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,8 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/Native/NUPakPathNodeIterator.h
 	SurrealEngine/Native/NUPakPawnPathNodeIterator.cpp
 	SurrealEngine/Native/NUPakPawnPathNodeIterator.h
+	SurrealEngine/Native/NRMusicPlayer.cpp
+	SurrealEngine/Native/NRMusicPlayer.h
 	SurrealEngine/Native/NBorderWindow.cpp
 	SurrealEngine/Native/NBorderWindow.h
 	SurrealEngine/Native/NButtonWindow.cpp
@@ -400,6 +402,7 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/UObject/UFlag.h
 	SurrealEngine/UObject/UConSys.cpp
 	SurrealEngine/UObject/UConSys.h
+	SurrealEngine/UObject/URMusicPlayer.h
 	SurrealEngine/Collision/TopLevel/CollisionSystem.cpp
 	SurrealEngine/Collision/TopLevel/CollisionSystem.h
 	SurrealEngine/Collision/TopLevel/CollisionHit.h

--- a/SurrealEngine/Native/NRMusicPlayer.cpp
+++ b/SurrealEngine/Native/NRMusicPlayer.cpp
@@ -1,0 +1,122 @@
+
+#include "Precomp.h"
+#include "NRMusicPlayer.h"
+
+#include "Utils/Logger.h"
+#include "VM/NativeFunc.h"
+#include "VM/ScriptCall.h"
+#include "VM/Frame.h"
+
+void NRMusicPlayer::RegisterFunctions()
+{
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_Startup", &NRMusicPlayer::RMusic_Startup, 0);
+    RegisterVMNativeFunc_2("RMusic_Player", "RMusic_LoadPlugin", &NRMusicPlayer::RMusic_LoadPlugin, 0);
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_UnloadPlugin", &NRMusicPlayer::RMusic_UnloadPlugin, 0);
+    RegisterVMNativeFunc_3("RMusic_Player", "RMusic_SetDSPParam", &NRMusicPlayer::RMusic_SetDSPParam, 0);
+    RegisterVMNativeFunc_0("RMusic_Player", "RMusic_Update", &NRMusicPlayer::RMusic_Update, 0);
+    RegisterVMNativeFunc_3("RMusic_Player", "RMusic_Play", &NRMusicPlayer::RMusic_Play, 0);
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_Pause", &NRMusicPlayer::RMusic_Pause, 0);
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_IsPlaying", &NRMusicPlayer::RMusic_IsPlaying, 0);
+    RegisterVMNativeFunc_0("RMusic_Player", "RMusic_SetCfgVolume", &NRMusicPlayer::RMusic_SetCfgVolume, 0);
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_SetVolume", &NRMusicPlayer::RMusic_SetVolume, 0);
+    RegisterVMNativeFunc_0("RMusic_Player", "RMusic_IncVolume", &NRMusicPlayer::RMusic_IncVolume, 0);
+    RegisterVMNativeFunc_0("RMusic_Player", "RMusic_DecVolume", &NRMusicPlayer::RMusic_DecVolume, 0);
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_GetVolume", &NRMusicPlayer::RMusic_GetVolume, 0);
+    RegisterVMNativeFunc_0("RMusic_Player", "RMusic_Stop", &NRMusicPlayer::RMusic_Stop, 0);
+    RegisterVMNativeFunc_0("RMusic_Player", "RMusic_Close", &NRMusicPlayer::RMusic_Close, 0);
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_GetTotalTime", &NRMusicPlayer::RMusic_GetTotalTime, 0);
+    RegisterVMNativeFunc_1("RMusic_Player", "RMusic_GetCurrentTime", &NRMusicPlayer::RMusic_GetCurrentTime, 0);
+}
+
+void NRMusicPlayer::RMusic_Startup(BitfieldBool& ReturnValue)
+{
+    // Since we'll use the built-in music support, we don't have to initialize anything here.
+    ReturnValue = true;
+}
+
+void NRMusicPlayer::RMusic_LoadPlugin(std::string& Plugin, BitfieldBool& ReturnValue)
+{
+    // no-op
+}
+
+void NRMusicPlayer::RMusic_UnloadPlugin(std::string& Plugin)
+{
+    // no-op
+}
+
+void NRMusicPlayer::RMusic_SetDSPParam(std::string& Plugin, int index, float value)
+{
+    // maybe a no-op?
+    LogUnimplemented("RMusic_Player.RMusic_SetDSPParam()");
+}
+
+void NRMusicPlayer::RMusic_Update()
+{
+    // Since we don't use fmod, this is a no-op
+}
+
+void NRMusicPlayer::RMusic_Play(std::string File, bool Loop, BitfieldBool& ReturnValue)
+{
+    LogUnimplemented("RMusic_Player.RMusic_Play()");
+    ReturnValue = false;
+}
+
+void NRMusicPlayer::RMusic_Pause(bool bPause)
+{
+    LogUnimplemented("RMusic_Player.RMusic_Pause()");
+}
+
+void NRMusicPlayer::RMusic_IsPlaying(BitfieldBool& ReturnValue)
+{
+    LogUnimplemented("RMusic_Player.RMusic_IsPlaying()");
+    ReturnValue = false;
+}
+
+void NRMusicPlayer::RMusic_SetCfgVolume()
+{
+    // Probably not a no-op
+    LogUnimplemented("RMusic_Player.RMusic_SetCfgVolume()");
+}
+
+void NRMusicPlayer::RMusic_SetVolume(int NewVolume)
+{
+    LogUnimplemented("RMusic_Player.RMusic_SetVolume()");
+}
+
+void NRMusicPlayer::RMusic_IncVolume()
+{
+    LogUnimplemented("RMusic_Player.RMusic_IncVolume()");
+}
+
+void NRMusicPlayer::RMusic_DecVolume()
+{
+    LogUnimplemented("RMusic_Player.RMusic_DecVolume()");
+}
+
+void NRMusicPlayer::RMusic_GetVolume(int& ReturnValue)
+{
+    LogUnimplemented("RMusic_Player.RMusic_GetVolume()");
+    ReturnValue = 0;
+}
+
+void NRMusicPlayer::RMusic_Stop()
+{
+    LogUnimplemented("RMusic_Player.RMusic_Stop()");
+}
+
+void NRMusicPlayer::RMusic_Close()
+{
+    // no-op
+}
+
+void NRMusicPlayer::RMusic_GetTotalTime(int& ReturnValue)
+{
+    LogUnimplemented("RMusic_Player.RMusic_GetTotalTime()");
+    ReturnValue = -1;
+}
+
+void NRMusicPlayer::RMusic_GetCurrentTime(int& ReturnValue)
+{
+    LogUnimplemented("RMusic_Player.RMusic_GetCurrentTime()");
+    ReturnValue = -1;
+}

--- a/SurrealEngine/Native/NRMusicPlayer.h
+++ b/SurrealEngine/Native/NRMusicPlayer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "UObject/UObject.h"
+
+/* RMusic_Player compatibility stuff
+ * Since RMusic_Player uses fmod and we have our solutions for playing most of the files this class plays,
+ * most of these functions will basically be no-ops
+ */
+
+class NRMusicPlayer
+{
+public:
+    static void RegisterFunctions();
+
+    static void RMusic_Startup(BitfieldBool& ReturnValue);
+    static void RMusic_LoadPlugin(std::string& Plugin, BitfieldBool& ReturnValue);
+    static void RMusic_UnloadPlugin(std::string& Plugin);
+    static void RMusic_SetDSPParam(std::string& Plugin, int index, float value);
+    static void RMusic_Update();
+    static void RMusic_Play(std::string File, bool Loop, BitfieldBool& ReturnValue);
+    static void RMusic_Pause(bool bPause);
+    static void RMusic_IsPlaying(BitfieldBool& ReturnValue);
+    static void RMusic_SetCfgVolume();
+    static void RMusic_SetVolume(int NewVolume);
+    static void RMusic_IncVolume();
+    static void RMusic_DecVolume();
+    static void RMusic_GetVolume(int& ReturnValue);
+    static void RMusic_Stop();
+    static void RMusic_Close();
+    static void RMusic_GetTotalTime(int& ReturnValue);
+    static void RMusic_GetCurrentTime(int& ReturnValue);
+};

--- a/SurrealEngine/Package/PackageManager.cpp
+++ b/SurrealEngine/Package/PackageManager.cpp
@@ -31,6 +31,7 @@
 #include "UObject/U227Emitter.h"
 #include "UObject/U227Projector.h"
 #include "UObject/U227SkeletalMeshInstance.h"
+#include "UObject/URMusicPlayer.h"
 #include "VM/NativeFunc.h"
 #include "Native/NActor.h"
 #include "Native/N227Emitter.h"
@@ -82,6 +83,7 @@
 #include "Native/NListWindow.h"
 #include "Native/NModalWindow.h"
 #include "Native/NRadioBoxWindow.h"
+#include "Native/NRMusicPlayer.h"
 #include "Native/NRootWindow.h"
 #include "Native/NScaleManagerWindow.h"
 #include "Native/NScaleWindow.h"
@@ -895,6 +897,11 @@ void PackageManager::RegisterFunctions()
 		NWebResponse::RegisterFunctions();
 		NWindow::RegisterFunctions();
 	}
+
+	if (fs::exists(gameSystemFolderPath / "RMusicPlayer.u"))
+	{
+		NRMusicPlayer::RegisterFunctions();
+	}
 }
 
 void PackageManager::RegisterNativeClasses()
@@ -908,6 +915,7 @@ void PackageManager::RegisterNativeClasses()
 	NameString conSysPackage = "ConSys";
 	NameString deusExPackage = "DeusEx";
 	NameString deusExTextPackage = "DeusExText";
+	NameString RMusicPlayerPackage = "RMusicPlayer";
 
 	RegisterNativeClass<UObject>(corePackage, "Object");
 	RegisterNativeClass<UPackage>(corePackage, "Package");
@@ -1175,6 +1183,12 @@ void PackageManager::RegisterNativeClasses()
 		RegisterNativeClass<UConversation>(conSysPackage, "Conversation", "ConObject");
 		RegisterNativeClass<UConversationList>(conSysPackage, "ConversationList", "ConObject");
 		RegisterNativeClass<UConversationMissionList>(conSysPackage, "ConversationMissionList", "ConObject");
+	}
+
+	if (fs::exists(gameSystemFolderPath / "RMusicPlayer.u"))
+	{
+		RegisterNativeClass<URMusic_Component>(RMusicPlayerPackage, "RMusic_Component", "Actor");
+		RegisterNativeClass<URMusic_Player>(RMusicPlayerPackage, "RMusic_Player", "RMusic_Component");
 	}
 }
 

--- a/SurrealEngine/UObject/PropertyOffsets.cpp
+++ b/SurrealEngine/UObject/PropertyOffsets.cpp
@@ -5439,6 +5439,47 @@ static void InitPropertyOffsets_SkeletalMeshInstance(PackageManager* packages)
 
 //////////////////////////////////////////
 
+PropertyDataOffsets_RMusic_Player PropOffsets_RMusic_Player;
+
+static void InitPropertyOffsets_RMusic_Player(PackageManager* packages)
+{
+	// Early bailout.
+	// If RMusicPlayer is not available then we don't need it
+	if (!fs::exists(packages->GetSystemFolderPath() / "RMusicPlayer.u"))
+	{
+		memset(&PropOffsets_RMusic_Player, 0xff, sizeof(PropOffsets_RMusic_Player));
+		return;
+	}
+
+	auto cls = UObject::TryCast<UClass>(packages->GetPackage("RMusicPlayer")->GetUObject("Class", "RMusic_Player"));
+	if (!cls)
+	{
+		memset(&PropOffsets_RMusic_Player, 0xff, sizeof(PropOffsets_RMusic_Player));
+		return;
+	}
+	
+	PropOffsets_RMusic_Player.RMusic_Volume = cls->GetPropertyDataOffset("RMusic_Volume");
+	PropOffsets_RMusic_Player.bAlwaysLoadCodecs = cls->GetPropertyDataOffset("bAlwaysLoadCodecs");
+	PropOffsets_RMusic_Player.RMusic_PluginsDirectory = cls->GetPropertyDataOffset("RMusic_PluginsDirectory");
+	PropOffsets_RMusic_Player.RMusic_Directory = cls->GetPropertyDataOffset("RMusic_Directory");
+	PropOffsets_RMusic_Player.bIncludeDebugInfo = cls->GetPropertyDataOffset("bIncludeDebugInfo");
+	PropOffsets_RMusic_Player.bAuthoritative = cls->GetPropertyDataOffset("bAuthoritative");
+	PropOffsets_RMusic_Player.bUseCurrentPaths = cls->GetPropertyDataOffset("bUseCurrentPaths");
+	PropOffsets_RMusic_Player.FaderUpdateTime = cls->GetPropertyDataOffset("FaderUpdateTime");
+	PropOffsets_RMusic_Player.NextTrack = cls->GetPropertyDataOffset("NextTrack");
+	PropOffsets_RMusic_Player.NextLoop = cls->GetPropertyDataOffset("NextLoop");
+	PropOffsets_RMusic_Player.bIsOn = cls->GetPropertyDataOffset("bIsOn");
+	PropOffsets_RMusic_Player.RMusic_LocalPlayer = cls->GetPropertyDataOffset("RMusic_LocalPlayer");
+	PropOffsets_RMusic_Player.RMusic_CurLevel = cls->GetPropertyDataOffset("RMusic_CurLevel");
+	PropOffsets_RMusic_Player.RMusic_OldLevel = cls->GetPropertyDataOffset("RMusic_OldLevel");
+	PropOffsets_RMusic_Player.bHasDSP = cls->GetPropertyDataOffset("bHasDSP");
+	PropOffsets_RMusic_Player.fDSPUpdateTime = cls->GetPropertyDataOffset("fDSPUpdateTime");
+	PropOffsets_RMusic_Player.fDSPUpdateDelay = cls->GetPropertyDataOffset("fDSPUpdateDelay");
+	PropOffsets_RMusic_Player.nextEvent = cls->GetPropertyDataOffset("nextEvent");
+}
+
+//////////////////////////////////////////
+
 void InitPropertyOffsets(PackageManager* packages)
 {
 	InitPropertyOffsets_Object(packages);
@@ -5519,6 +5560,7 @@ void InitPropertyOffsets(PackageManager* packages)
 	InitPropertyOffsets_InternetLink(packages);
 	InitPropertyOffsets_UdpLink(packages);
 	InitPropertyOffsets_TcpLink(packages);
+	InitPropertyOffsets_RMusic_Player(packages);
 	if (packages->IsUnreal1())
 	{
 		InitPropertyOffsets_UPakPathNodeIterator(packages);

--- a/SurrealEngine/UObject/PropertyOffsets.h
+++ b/SurrealEngine/UObject/PropertyOffsets.h
@@ -4335,3 +4335,27 @@ struct PropertyDataOffsets_AnimationNotify
 };
 
 extern PropertyDataOffsets_AnimationNotify PropOffsets_AnimationNotify;
+
+struct PropertyDataOffsets_RMusic_Player
+{
+	PropertyDataOffset RMusic_Volume;
+	PropertyDataOffset bAlwaysLoadCodecs;
+	PropertyDataOffset RMusic_PluginsDirectory;
+	PropertyDataOffset RMusic_Directory;
+	PropertyDataOffset bIncludeDebugInfo;
+	PropertyDataOffset bAuthoritative;
+	PropertyDataOffset bUseCurrentPaths;
+	PropertyDataOffset FaderUpdateTime;
+	PropertyDataOffset NextTrack;
+	PropertyDataOffset NextLoop;
+	PropertyDataOffset bIsOn;
+	PropertyDataOffset RMusic_LocalPlayer;
+	PropertyDataOffset RMusic_CurLevel;
+	PropertyDataOffset RMusic_OldLevel;
+	PropertyDataOffset bHasDSP;
+	PropertyDataOffset fDSPUpdateTime;
+	PropertyDataOffset fDSPUpdateDelay;
+	PropertyDataOffset nextEvent;
+};
+
+extern PropertyDataOffsets_RMusic_Player PropOffsets_RMusic_Player;

--- a/SurrealEngine/UObject/URMusicPlayer.h
+++ b/SurrealEngine/UObject/URMusicPlayer.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "UActor.h"
+
+/*
+ * RMusicPlayer compat classes
+ * Does the absolute bare minimum to get things running
+ **/
+
+class URMusic_Component : public UActor
+{
+public:
+    using UActor::UActor;
+    // "Empty" base class
+};
+
+class URMusic_Player : public URMusic_Component
+{
+public:
+    using URMusic_Component::URMusic_Component;
+
+    int& RMusic_Volume() { return Value<int>(PropOffsets_RMusic_Player.RMusic_Volume); }
+    BitfieldBool bAlwaysLoadCodecs() { return BoolValue(PropOffsets_RMusic_Player.bAlwaysLoadCodecs); }
+    std::string& RMusic_PluginsDirectory() { return Value<std::string>(PropOffsets_RMusic_Player.RMusic_PluginsDirectory); }
+    std::string& RMusic_Directory() { return Value<std::string>(PropOffsets_RMusic_Player.RMusic_Directory); }
+    BitfieldBool bIncludeDebugInfo() { return BoolValue(PropOffsets_RMusic_Player.bIncludeDebugInfo); }
+    BitfieldBool bAuthoritative() { return BoolValue(PropOffsets_RMusic_Player.bAuthoritative); }
+    BitfieldBool bUseCurrentPaths() { return BoolValue(PropOffsets_RMusic_Player.bUseCurrentPaths); }
+    float& FaderUpdateTime() { return Value<float>(PropOffsets_RMusic_Player.FaderUpdateTime); }
+    std::string& NextTrack() { return Value<std::string>(PropOffsets_RMusic_Player.NextTrack); }
+    BitfieldBool NextLoop() { return BoolValue(PropOffsets_RMusic_Player.NextLoop); }
+    BitfieldBool bIsOn() { return BoolValue(PropOffsets_RMusic_Player.bIsOn); }
+    UPlayerPawn*& RMusic_LocalPlayer() { return Value<UPlayerPawn*>(PropOffsets_RMusic_Player.RMusic_LocalPlayer); }
+    ULevelInfo*& RMusic_CurLevel() { return Value<ULevelInfo*>(PropOffsets_RMusic_Player.RMusic_CurLevel); }
+    ULevelInfo*& RMusic_OldLevel() { return Value<ULevelInfo*>(PropOffsets_RMusic_Player.RMusic_OldLevel); }
+    BitfieldBool bHasDSP() { return BoolValue(PropOffsets_RMusic_Player.bHasDSP); }
+    float& fDSPUpdateTime() { return Value<float>(PropOffsets_RMusic_Player.fDSPUpdateTime); }
+    float& fDSPUpdateDelay() { return Value<float>(PropOffsets_RMusic_Player.fDSPUpdateDelay); }
+    // nextEvent's RMusic_ControllerEx is not a native class
+};


### PR DESCRIPTION
This adds stub functions and classes for RMusicPlayer, a plugin with native code.

Since we cannot load in any native mods, only thing we can do is to reimplement em.

RMusicPlayer utilises fmod, which we don't. Due to this a significant amount of native functions it has are implemented as no-ops here.

Registering the classes is done only when `RMusicPlayer.u` is present in System folder.

With this PR I got EXU2 running on Surreal Engine. There have been some crashes but they're about failing to spawn the player actor.