### PR TITLE
Fix/bug Save and Load in Unreal not Possible

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -241,7 +241,7 @@ void Engine::Run()
 		{
 			UnrealURL url(ClientTravelInfo.URL);
 			LoadFromSaveFile(url);
-			LoginPlayer();
+			PossessSavedPlayer();
 		}
 
 		if (!ClientTravelInfo.URL.Map.empty())
@@ -733,22 +733,69 @@ void Engine::LoadFromSaveFile(const UnrealURL& url)
 
 	GetLevelInfoObject();
 
-	/*
+	// Same as LoadMap: these are session/engine identity, not save data, and must be
+	// re-established on every load regardless of what the package/save file contains.
 	LevelInfo->ComputerName() = "MyComputer";
 	LevelInfo->HubStackLevel() = 0; // To do: handle level hubs
-	*/
 	LevelInfo->EngineVersion() = LaunchInfo.gameVersionString + " SE";
 	if (LaunchInfo.ue1Version > 219)
 		LevelInfo->MinNetVersion() = LaunchInfo.gameVersionString + " SE";
 	LevelInfo->bHighDetailMode() = true;
-	/*
 	LevelInfo->NetMode() = 0; // NM_StandAlone
 	LevelInfo->DefaultTexture() = engine->DefaultTexture;
-	*/
+
+	// LevelInfo->URL is a native engine field, never a serialized script property, so it is
+	// never restored by loading the save package and must be rebuilt here.
+	LevelInfo->URL = UnrealURL(LevelPackage->GetPackageName().ToString());
 
 	GetLevelObject();
 
 	LinkActorsToLevel();
+
+	// BUG-006: engine->GameInfo is otherwise only assigned in LoadMap, so without this it keeps
+	// pointing at the previous, now-unloaded level's GameInfo. LevelInfo->Game() is a normal
+	// script property, so it round-trips through the save correctly; just re-point at it.
+	GameInfo = UObject::Cast<UGameInfo>(LevelInfo->Game());
+	if (!GameInfo)
+		Exception::Throw("Save file has no GameInfo actor for " + LevelPackage->GetPackageName().ToString() + "!");
+}
+
+void Engine::PossessSavedPlayer()
+{
+	// Loading a save must not reuse LoginPlayer, because that always calls GameInfo.Login,
+	// which always spawns a brand new pawn. The save package already contains the actual saved
+	// pawn - deserialized with its real position, health and inventory - sitting in
+	// Level->Actors. Find and possess that one directly instead.
+	UPlayerPawn* pawn = nullptr;
+	for (UActor* actor : Level->Actors)
+	{
+		UPlayerPawn* p = UObject::TryCast<UPlayerPawn>(actor);
+		if (p && p->bIsPlayer())
+		{
+			pawn = p;
+			break;
+		}
+	}
+
+	if (!pawn)
+		Exception::Throw("Save file has no player pawn for " + LevelPackage->GetPackageName().ToString() + "!");
+
+	if (auto pawnExt = UObject::TryCast<UPlayerPawnExt>(pawn))
+	{
+		// FlagBase is Transient (not saved), so it needs the same reconstruction LoginPlayer
+		// does for a fresh spawn.
+		if (!pawnExt->FlagBase())
+		{
+			auto flagBaseCls = packages->FindClass("Extension.FlagBase");
+			pawnExt->FlagBase() = UObject::Cast<UFlagBase>(packages->GetTransientPackage()->NewObject("FlagBase", flagBaseCls, ObjectFlags::Transient));
+		}
+	}
+
+	viewport->Actor() = pawn;
+	viewport->Actor()->Player() = viewport;
+	CallEvent(viewport->Actor(), EventName::Possess);
+
+	render->OnMapLoaded();
 }
 
 void Engine::SaveGameToSlot(int32_t slotNum, const std::string& saveDescription) const

--- a/SurrealEngine/Engine.h
+++ b/SurrealEngine/Engine.h
@@ -78,6 +78,7 @@ public:
 	void SaveGameToSlot(int32_t slotNum, const std::string& saveDescription) const;
 	void UnloadMap();
 	void LoginPlayer();
+	void PossessSavedPlayer();
 
 	UObject* FindObject(NameString name, NameString className);
 

--- a/SurrealEngine/Render/VisibleMesh.cpp
+++ b/SurrealEngine/Render/VisibleMesh.cpp
@@ -984,7 +984,7 @@ bool VisibleMesh::DrawLodMeshFaceDX(VisibleFrame* frame, UActor* actor, UActor* 
 void VisibleMesh::DrawDebugInfo(VisibleFrame* frame, UActor* actor)
 {
 	auto pawn = UObject::TryCast<UPawn>(actor);
-	if (!pawn)
+	if (!pawn || !pawn->StateFrame)
 		return;
 
 	vec3 end;

--- a/SurrealEngine/UObject/UClass.cpp
+++ b/SurrealEngine/UObject/UClass.cpp
@@ -733,7 +733,7 @@ void UClass::LoadProperties(PropertyDataBlock* propertyBlock)
 						NameString outerSectionName = outer->package->GetPackageName().ToString() + "." + outer->Name.ToString();
 						NameString outerConfigName = outer->ClassConfigName;
 						if (outerConfigName.IsNone()) outerConfigName = "system";
-						value = package->GetPackageManager()->GetIniValue(outerConfigName, outerSectionName, prop->Name);
+						value = package->GetPackageManager()->GetIniValue(outerConfigName, outerSectionName, name);
 					}
 				}
 				else if (AllFlags(prop->PropFlags, PropertyFlags::Config))

--- a/SurrealEngine/UObject/UClass.cpp
+++ b/SurrealEngine/UObject/UClass.cpp
@@ -936,19 +936,50 @@ void UClass::SaveProperties(PropertyDataBlock* propertyBlock)
 		LoadProperties(&PropertyData);
 	}
 
-	// GlobalConfig properties needs to be propagated to all derived classes
+	// GlobalConfig properties are shared across the whole class hierarchy that
+	// declares them, so a change must propagate to every class deriving from the
+	// *declaring* class - not just classes deriving from `this`. Otherwise sibling
+	// classes (e.g. UMenuLoadGameClientWindow vs UMenuSaveGameClientWindow, which
+	// both inherit globalconfig SlotNames[] from UMenuSlotClientWindow) keep a stale
+	// default until the next restart re-reads the ini.
+	Array<UStruct*> propagationRoots;
+	propagationRoots.push_back(this);
+	for (UProperty* prop : Properties)
+	{
+		if (AnyFlags(prop->PropFlags, PropertyFlags::GlobalConfig))
+		{
+			if (UClass* declaring = UObject::TryCast<UClass>(prop->Outer()))
+			{
+				bool known = false;
+				for (UStruct* root : propagationRoots)
+					if (root == declaring) { known = true; break; }
+				if (!known)
+					propagationRoots.push_back(declaring);
+			}
+		}
+	}
+
 	for (GCObject* gcObj : GC::GetObjects())
 	{
 		if (UClass* cls = dynamic_cast<UClass*>(gcObj))
 		{
-			for (UStruct* base = cls->BaseStruct; base; base = base->BaseStruct)
+			bool propagate = false;
+			for (UStruct* base = cls; base && !propagate; base = base->BaseStruct)
 			{
-				if (base == this)
+				for (UStruct* root : propagationRoots)
 				{
-					LoadProperties(&cls->PropertyData);
-					break;
+					if (base == root)
+					{
+						propagate = true;
+						break;
+					}
 				}
 			}
+			// Reload through cls's own property list (not this->Properties), so the
+			// property offsets match cls's data block. this->Properties can be a
+			// superset of an ancestor/sibling's layout and would overrun its block.
+			if (propagate && cls != this)
+				cls->LoadProperties(&cls->PropertyData);
 		}
 	}
 }


### PR DESCRIPTION
Fixes 3 bugs regarding the save an load system:

1. it was not Possible to save a game, the save process did crash
2. a saved game was only visible after a restart of the games application, not in the same sesson
3. loading a saved game would crash after several seconds, due too an intermittend bug

Saved games are still not fully restored (interactions like movers, breakable glass etc.) are not working. 
This will be fixed later.