### PR TITLE
Fix movers and triggers breaking after loading a level

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -1998,6 +1998,17 @@ void Engine::LinkActorsToLevel()
 			Level->Light.AddLight(actor);
 		}
 	}
+
+	// BasedActors (who is standing on me, so I carry them when I move) is native, runtime-only
+	// state - never serialized - while ActorBase() (what am I standing on) is a normal property
+	// that does round-trip through a package/save. Without this, an actor that starts a level (or
+	// a load) already resting on a mover has its own ActorBase() pointer intact, but the mover's
+	// own BasedActors list is empty, so the mover has no way to carry it along once it moves.
+	for (UActor* actor : Level->Actors)
+	{
+		if (actor)
+			actor->RelinkBasedActor();
+	}
 }
 
 const char* Engine::keynames[256] =

--- a/SurrealEngine/UObject/UActor.cpp
+++ b/SurrealEngine/UObject/UActor.cpp
@@ -374,6 +374,15 @@ void UActor::SetBase(UActor* newBase, bool sendBaseChangeEvent)
 	}
 }
 
+void UActor::RelinkBasedActor()
+{
+	if (ActorBase() && ActorBase() != Level())
+	{
+		ActorBase()->AddBasedActor(this);
+		ActorBase()->StandingCount() = (uint8_t)std::min<size_t>(ActorBase()->BasedActors.size(), 0xff);
+	}
+}
+
 void UActor::Tick(float elapsed)
 {
 	TickAnimation(elapsed);

--- a/SurrealEngine/UObject/UActor.h
+++ b/SurrealEngine/UObject/UActor.h
@@ -412,6 +412,11 @@ public:
 	void InitBase();
 
 	void SetBase(UActor* newBase, bool sendBaseChangeEvent);
+	// Re-registers this actor into ActorBase()->BasedActors without firing Attach/BaseChange
+	// events. BasedActors is native runtime-only state (never serialized), unlike ActorBase()
+	// itself, so a freshly loaded actor whose ActorBase() property already points at another
+	// actor needs this to make that relationship work in both directions again.
+	void RelinkBasedActor();
 	void SetOwner(UActor* newOwner);
 	virtual void InitActorZone();
 	virtual void UpdateActorZone();

--- a/SurrealEngine/UObject/UObject.cpp
+++ b/SurrealEngine/UObject/UObject.cpp
@@ -66,14 +66,6 @@ void UObject::Load(ObjectStream* stream)
 		int64_t probeMask = stream->ReadInt64();
 		int32_t latentAction = stream->ReadInt32();
 
-		for (int i = 0; i < 64; i++)
-		{
-			if (((1ULL >> (uint64_t)i) & 1) == 1)
-			{
-				DisableEvent(ToNameString((EventName)i));
-			}
-		}
-
 		int offset = -1;
 		if (func)
 			offset = stream->ReadIndex();
@@ -89,7 +81,15 @@ void UObject::Load(ObjectStream* stream)
 					StateFrame = std::make_shared<Frame>(this, nullptr);
 					StateFrame->SetState(func);
 					StateFrame->StatementIndex = index;
-					StateFrame->LatentState = NativeFunctions::LatentActionByIndex[latentAction];
+					if (latentAction >= 0 && (size_t)latentAction < NativeFunctions::LatentActionByIndex.size())
+					{
+						StateFrame->LatentState = NativeFunctions::LatentActionByIndex[latentAction];
+					}
+					else
+					{
+						LogMessage("UObject::Load encountered out of bounds latent action index");
+						StateFrame->LatentState = LatentRunState::Continue;
+					}
 				}
 				else
 				{
@@ -107,6 +107,14 @@ void UObject::Load(ObjectStream* stream)
 		else if (state)
 		{
 			LogMessage("UObject::Load encountered object with a state object but no function");
+		}
+
+		for (int i = 0; i < 64; i++)
+		{
+			if ((probeMask >> i) & 1)
+			{
+				DisableEvent(ToNameString((EventName)i));
+			}
 		}
 	}
 
@@ -127,13 +135,9 @@ void UObject::Save(PackageStreamWriter* stream)
 {
 	if (AllFlags(Flags, ObjectFlags::HasStack))
 	{
-#if 1
-		stream->WriteIndex(0);
-		stream->WriteIndex(0);
-		stream->WriteInt64(0);
-		stream->WriteInt32(0);
-#else
-		// To do: state and func may not always be the same
+		// func and state: in this engine's VM, a StateFrame can only ever be suspended in
+		// state code, so func (raw StateFrame->Func) and state (StateFrame->Func cast to
+		// UState) always point at the same object here.
 		UStruct* func = StateFrame ? StateFrame->Func : nullptr;
 		UState* state = StateFrame ? UObject::TryCast<UState>(StateFrame->Func) : nullptr;
 		int32_t latentAction = 0;
@@ -142,16 +146,23 @@ void UObject::Save(PackageStreamWriter* stream)
 		int64_t probeMask = 0;
 		for (int i = 0; i < 64; i++)
 		{
-			if (IsEventDisabled(ToNameString((EventName)i)))
+			if (IsEventDisabled((EventName)i))
 			{
 				probeMask |= 1ULL << (uint64_t)i;
 			}
 		}
 
-		if (StateFrame && StateFrame->LatentState != LatentRunState::Stop)
+		// A StateFrame can outlive its state: GotoState("") (what a bTriggerOnceOnly mover does
+		// once it has fired) keeps the frame but sets Func to null, while LatentState is left at
+		// whatever it was - and defaults to Continue, never Stop. Func must be checked, or this
+		// dereferences null; Func->Code can likewise be null for a state with no bytecode. Both
+		// cases write a null func below, which is what Load needs to restore the actor dormant.
+		if (StateFrame && StateFrame->Func && StateFrame->LatentState != LatentRunState::Stop)
 		{
-			latentAction = NativeFunctions::IndexForLatentAction[StateFrame->LatentState];
-			offset = StateFrame->Func->Code->FindOffset(StateFrame->StatementIndex);
+			auto it = NativeFunctions::IndexForLatentAction.find(StateFrame->LatentState);
+			latentAction = (it != NativeFunctions::IndexForLatentAction.end()) ? it->second : 0;
+			if (StateFrame->Func->Code)
+				offset = StateFrame->Func->Code->FindOffset((int)StateFrame->StatementIndex);
 		}
 
 		stream->WriteObject(func);
@@ -160,7 +171,6 @@ void UObject::Save(PackageStreamWriter* stream)
 		stream->WriteInt32(latentAction);
 		if (func)
 			stream->WriteIndex(offset);
-#endif
 	}
 
 	if (!UObject::TryCast<UClass>(this))
@@ -411,6 +421,13 @@ bool UObject::IsEventEnabled(EventName name) const
 	return it == DisabledEvents.end() || it->second.find(ToNameString(name)) == it->second.end();
 }
 
+bool UObject::IsEventDisabled(EventName name) const
+{
+	NameString stateName = GetStateName();
+	auto it = DisabledEvents.find(stateName);
+	return it != DisabledEvents.end() && it->second.find(ToNameString(name)) != it->second.end();
+}
+
 std::string UObject::PrintProperties()
 {
 	std::string result;
@@ -517,7 +534,14 @@ void UObject::GotoState(NameString stateName, const NameString& labelName)
 		StateFrame->SetState(newState);
 
 	if (newState)
+	{
+		// HasStack is otherwise only ever inherited from the original package's export table at
+		// load time. An actor that starts a level with no baked-in stack but enters a real state
+		// during play would otherwise never have that state written by Save() at all, silently
+		// losing it on the next save regardless of what state it's actually in.
+		Flags |= ObjectFlags::HasStack;
 		StateFrame->GotoLabel(labelName);
+	}
 
 	if (newState && oldState != newState)
 		CallEvent(this, EventName::BeginState);

--- a/SurrealEngine/UObject/UObject.h
+++ b/SurrealEngine/UObject/UObject.h
@@ -310,6 +310,7 @@ public:
 
 	bool IsEventEnabled(const NameString& name) const;
 	bool IsEventEnabled(EventName name) const;
+	bool IsEventDisabled(EventName name) const;
 
 	void EnableEvent(const NameString& name)
 	{

--- a/SurrealEngine/VM/Bytecode.h
+++ b/SurrealEngine/VM/Bytecode.h
@@ -14,7 +14,18 @@ public:
 
 	int FindStatementIndex(uint16_t offset) const
 	{
-		return OffsetToExpression.find(offset)->second->StatementIndex;
+		auto it = OffsetToExpression.find(offset);
+		return it != OffsetToExpression.end() ? it->second->StatementIndex : -1;
+	}
+
+	int FindOffset(int statementIndex) const
+	{
+		for (const auto& it : OffsetToExpression)
+		{
+			if (it.second->StatementIndex == statementIndex)
+				return it.first;
+		}
+		return -1;
 	}
 
 	int FindLabelIndex(const NameString& label)

--- a/SurrealEngine/VM/NativeFunc.cpp
+++ b/SurrealEngine/VM/NativeFunc.cpp
@@ -6,6 +6,7 @@ Array<UFunction*> NativeFunctions::FuncByIndex;
 Array<NativeFuncHandler> NativeFunctions::NativeByIndex;
 std::map<std::pair<NameString, NameString>, NativeFuncHandler> NativeFunctions::NativeByName;
 Array<LatentRunState> NativeFunctions::LatentActionByIndex;
+std::map<LatentRunState, int> NativeFunctions::IndexForLatentAction;
 
 void NativeFunctions::RegisterHandler(const NameString& className, const NameString& funcName, int nativeIndex, NativeFuncHandler handler)
 {
@@ -53,4 +54,5 @@ void RegisterLatentAction(int nativeIndex, LatentRunState latentAction)
 {
 	if (NativeFunctions::LatentActionByIndex.size() <= (size_t)nativeIndex) NativeFunctions::LatentActionByIndex.resize((size_t)nativeIndex + 1);
 	NativeFunctions::LatentActionByIndex[nativeIndex] = latentAction;
+	NativeFunctions::IndexForLatentAction[latentAction] = nativeIndex;
 }

--- a/SurrealEngine/VM/NativeFunc.h
+++ b/SurrealEngine/VM/NativeFunc.h
@@ -17,6 +17,7 @@ public:
 	static Array<NativeFuncHandler> NativeByIndex;
 	static std::map<std::pair<NameString, NameString>, NativeFuncHandler> NativeByName;
 	static Array<LatentRunState> LatentActionByIndex;
+	static std::map<LatentRunState, int> IndexForLatentAction;
 
 	static void RegisterHandler(const NameString& className, const NameString& funcName, int nativeIndex, NativeFuncHandler handler);
 	static void RegisterNativeFunc(UFunction* func);


### PR DESCRIPTION
Fixes the bug that movers could not be Triggert in a loaded save. Also fixes the bug that a player standing on a mover when saving, would fall to the ground. Fixes the "Breaking glass not possible after save" - bug i encountert in my playtrough - but that is probably because the glass also is a mover.

UObject::Save never actually wrote an actor's script state frame (the branch was stubbed to write zeros), so a mover or trigger mid- sequence always came back dormant after a load. Also set HasStack when an actor enters a state during play, and relink BasedActors after linking a level so movers still carry riders.