### PR TITLE
Fix "Translator lost on level travel"

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -213,18 +213,30 @@ void Engine::Run()
 			LevelInfo->NextSwitchCountdown() -= levelElapsed;
 			if (LevelInfo->NextSwitchCountdown() <= 0.0f)
 			{
+				// LoginPlayer only transfers travel actors when ClientTravelInfo.TravelType is
+				// TRAVEL_Relative, and TravelType is otherwise assigned only in ClientTravel. These
+				// NextURL routes never go through ClientTravel, so without setting it here they
+				// inherit whatever the last ClientTravel left behind (or TRAVEL_Absolute, the
+				// default) - which silently discarded the inventory the bNextItems branch exists
+				// specifically to carry. State the intent explicitly on each branch instead of
+				// depending on leftover state.
 				if (UnrealURL(LevelInfo->NextURL()).HasOption("restart"))
 				{
+					// Passes the level's own TravelInfo back in, so it means to preserve it.
+					ClientTravelInfo.TravelType = ETravelType::TRAVEL_Relative;
 					LoadMap(LevelInfo->URL, Level->TravelInfo);
 					LoginPlayer();
 				}
 				else if (LevelInfo->bNextItems())
 				{
+					ClientTravelInfo.TravelType = ETravelType::TRAVEL_Relative;
 					LoadMap(UnrealURL(LevelInfo->URL, LevelInfo->NextURL()), CreateTravelInfo(true));
 					LoginPlayer();
 				}
 				else
 				{
+					// Deliberately carries nothing - it passes no travel info at all.
+					ClientTravelInfo.TravelType = ETravelType::TRAVEL_Absolute;
 					LoadMap(UnrealURL(LevelInfo->URL, LevelInfo->NextURL()), {});
 					LoginPlayer();
 				}

--- a/SurrealEngine/UObject/ObjectTravelInfo.cpp
+++ b/SurrealEngine/UObject/ObjectTravelInfo.cpp
@@ -157,6 +157,18 @@ Array<UActor*> ActorTravelInfo::Accept(UPlayerPawn* pawn, const std::string& tra
 
 		for (UProperty* property : acceptedActor->GetAllTravelProperties())
 		{
+			// GetAllTravelProperties force-includes Inventory so Create() can walk the chain to
+			// find what to carry. Outside Deus Ex it is not a real UE1 travel property (Actor.uc:
+			// "var Inventory Inventory;", no travel keyword), and it must not be written back here:
+			// UE1 rebuilds the chain in Inventory.TravelPreAccept -> GiveTo -> AddInventory, which
+			// runs after this. Pre-linking it breaks scripts that ask whether the pawn already owns
+			// an item - Translator.TravelPreAccept skips its Super call when
+			// FindInventoryType(class) != None, and with the chain already wired it finds *itself*,
+			// so it never gets BecomeItem()/GotoState('Idle2') and arrives as a visible world pickup
+			// that no longer shows in the item list.
+			if (property->Name == "Inventory" && !AllFlags(property->PropFlags, PropertyFlags::Travel))
+				continue;
+
 			auto it = objInfo.Properties.find(property->Name.ToString());
 			if (it == objInfo.Properties.end())
 				continue;


### PR DESCRIPTION
The translator was no initialized properly after the travel, causing it to spawn as a world item. This is why it vanished from the item list.
Fixed by not restoring Inventory in Accept unless it is genuinely Travel-flagged, which it is only in Deus Ex - that path is unchanged.

Also fix the NextURL routes in Engine::Run: LoginPlayer transfers travel actors only when ClientTravelInfo.TravelType is TRAVEL_Relative