### PR TITLE
Fix GCRootNode list linked in the wrong direction

### DIFF
--- a/SurrealEngine/GC/GC.cpp
+++ b/SurrealEngine/GC/GC.cpp
@@ -8,9 +8,10 @@ static GCStats stats;
 
 GCRootNode::GCRootNode()
 {
+	next = roots;
+	prev = nullptr;
 	if (roots)
-		roots->next = this;
-	prev = roots;
+		roots->prev = this;
 	roots = this;
 }
 


### PR DESCRIPTION
The constructor built the root list in the opposite direction from what the destructor and GC::Collect() assume, so Collect() only ever marked the newest root, and destroying that root left the global head dangling at freed memory, corrupting the heap on the next allocation.