### PR TITLE
Fix Deus Ex conversation choice clicks

### DIFF
--- a/SurrealEngine/Packages/Extension/Windows/TabGroup/URootWindow.cpp
+++ b/SurrealEngine/Packages/Extension/Windows/TabGroup/URootWindow.cpp
@@ -6,6 +6,7 @@
 #include "Packages/Engine/Resources/USound.h"
 #include "Packages/Engine/Resources/Textures/UTexture.h"
 #include "Packages/Extension/Windows/UGC.h"
+#include "Packages/Extension/Windows/Text/UButtonWindow.h"
 #include "Engine.h"
 
 void URootWindow::EnablePositionalSound(std::optional<bool> bEnable)
@@ -335,8 +336,24 @@ bool URootWindow::OnWindowMouseUp(const Point& pos, EInputKey key)
 	float relativeX = 0.0f, relativeY = 0.0f;
 	UWindow* focus = GetCursorFocus(relativeX, relativeY);
 
-	if (focus->RawMouseButtonPressed(relativeX, relativeY, key, EInputType::IST_Release))
+	const bool rawMouseHandled = focus->RawMouseButtonPressed(relativeX, relativeY, key, EInputType::IST_Release);
+	if (rawMouseHandled)
+	{
+		// Deus Ex conversation choices place a raw-input child over the button.
+		if (key == IK_LeftMouse)
+		{
+			for (UWindow* cur = focus; cur; cur = cur->parentOwner())
+			{
+				if (UObject::GetUClassFullName(cur) == "DeusEx.ConChoiceWindow")
+				{
+					if (UButtonWindow* button = UObject::TryCast<UButtonWindow>(cur))
+						button->ActivateButton(key);
+					break;
+				}
+			}
+		}
 		return true;
+	}
 
 	if (!focus->bIsSensitive())
 		return IsModalOpen();


### PR DESCRIPTION
## Problem

In Deus Ex, the first conversation with Paul Denton at the Liberty Island
docks reaches a choice window, but clicking a choice can leave the conversation
stuck in `WaitForInput`.

The cursor is focused on an `Extension.TileWindow` inside
`DeusEx.ConChoiceWindow`. That raw-input child handles the mouse release, so
`URootWindow::OnWindowMouseUp` returns before normal release propagation can
activate the ancestor choice button.

## Change

When a raw handler consumes a left-button release, walk the focused window's
ancestor chain. If it contains exactly `DeusEx.ConChoiceWindow`, activate that
button before returning.

This is deliberately limited to consumed left-button releases and the shipped
Deus Ex conversation-choice class. Unhandled releases still follow the
existing path, so normal buttons are not activated twice. Inventory buttons
and unrelated window behavior are outside this PR.

## Reproduction and evidence

The recorded before/after scenario uses both Deus Ex demo 1.002f and GOTY
retail 1112fm on `01_NYC_UNATCOIsland`:

- before: focus was `Extension.TileWindow`, the choice remained visible, and
  `ConPlay` stayed in `WaitForInput`;
- after: the same release removed the choice and advanced `ConPlay` to
  `WaitForSpeech`.

## Validation

- based directly on current `dpjudas/master` (`2d47264c`);
- `RelWithDebInfo` `SurrealEngine` build passed;
- current upstream registers no CTest tests;
- the demo and retail before/after gameplay evidence was produced before the
  current UObject source split, so this remains a draft pending one fresh
  human gameplay pass of this exact commit.

AI assistance was used to reconstruct and compile-check this focused patch.
The PR is left as a draft for final contributor review and exact-commit runtime
confirmation.
