### PR TITLE
Restore MayFall handling for walking pawns

### DIFF
--- a/SurrealEngine/Packages/Engine/Actors/UActor_PhysWalking.cpp
+++ b/SurrealEngine/Packages/Engine/Actors/UActor_PhysWalking.cpp
@@ -51,6 +51,7 @@ void UActor::TickWalking(float elapsed)
 			if (ShouldAbortMovementTick(PHYS_Walking))
 				break;
 
+			vec3 iterationStart = Location();
 			vec3 moveDelta = vel * timeLeft;
 
 			//movement logic was inverted, causing overhaed buttons to be to easy to push
@@ -116,8 +117,38 @@ void UActor::TickWalking(float elapsed)
 			}
 
 			// Can we reach the ground from here if we step down?
-			if (!TryStepToGround(stepDownDelta))
-				return;
+			CollisionHit floorHit = TryMove(stepDownDelta, true);
+			if (floorHit.Fraction == 1.0f || floorHit.Normal.z < 0.7071f)
+			{
+				if (pawn->bCanJump())
+				{
+					CallEvent(this, EventName::MayFall);
+					if (ShouldAbortMovementTick(PHYS_Walking))
+						return;
+
+					if (!pawn->bCanJump())
+					{
+						Velocity() = vec3(0.0f);
+						Acceleration() = vec3(0.0f);
+						TryMove(iterationStart - Location());
+						return;
+					}
+
+					// The event may have moved the pawn while leaving it in walking physics.
+					floorHit = TryMove(stepDownDelta, true);
+				}
+
+				if (floorHit.Fraction == 1.0f || floorHit.Normal.z < 0.7071f)
+				{
+					SetPhysics(PHYS_Falling);
+					SetBase(nullptr, true);
+					return;
+				}
+			}
+
+			floorHit = TryMove(stepDownDelta);
+			if (floorHit.Fraction != 1.0f)
+				SetBase(floorHit.Actor, true);
 		}
 	}
 	else


### PR DESCRIPTION
## Summary

Restore the existing `MayFall` event opportunity when a moving pawn reaches
unsupported space while using walking physics.

The walking update now:

- gives script one `MayFall` callback before committing the normal transition
  to falling;
- preserves destruction or physics-mode changes made by that callback;
- treats a callback that disables `bCanJump` as a veto, stops the rejected
  movement, and moves the pawn back toward its supported starting position
  using the normal collision-aware movement path; and
- rechecks support after an allowed callback before applying the existing fall
  and base-clearing behavior.

## Bot impact

Bot scripts already use `MayFall` and `bCanJump` to decide whether an
unsupported step should be accepted. The native walking path previously moved
straight into falling without exposing that decision point.

Restoring the callback lets bots reject an unsafe step, stop at the supported
side, and allow their normal movement logic to choose another action. The fix
does not add pain-zone checks, map-specific rules, bot-class policy, or custom
trajectory prediction to native physics. If script allows the fall, walking
continues into the existing falling behavior.

## Validation

- Windows x64 `RelWithDebInfo` `SurrealEngine` build passes.
- `git diff --check` passes.
- All CTests registered by the current upstream build were enumerated and run;
  current upstream registers zero tests.

Game-backed review is still recommended for bot edge avoidance, intentional
drops, callback-driven physics changes, and ordinary non-bot falling behavior.
