### PR TITLE
Correct Pawn.CanSee vision cone calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.15)
 
 project(SurrealEngine)
 
+include(CTest)
+
 add_subdirectory(Thirdparty/openmpt)
 add_subdirectory(SurrealGPU)
 add_subdirectory(SurrealWidgets)
@@ -558,6 +560,7 @@ set(SURREALCOMMON_SOURCES
 	SurrealEngine/Packages/Engine/Actors/NavigationPoint/UTriggerMarker.h
 	SurrealEngine/Packages/Engine/Actors/NavigationPoint/UWarpZoneMarker.h
 	SurrealEngine/Packages/Engine/Actors/Pawn/UCamera.h
+	SurrealEngine/Packages/Engine/Actors/Pawn/PawnVision.h
 	SurrealEngine/Packages/Engine/Actors/Pawn/UPawn.cpp
 	SurrealEngine/Packages/Engine/Actors/Pawn/UPawn.h
 	SurrealEngine/Packages/Engine/Actors/Pawn/UPlayerPawn.cpp
@@ -1071,6 +1074,13 @@ set_target_properties(SurrealEditor PROPERTIES CXX_STANDARD 20)
 add_executable(SurrealDebugger ${SURREALDEBUGGER_SOURCES})
 target_link_libraries(SurrealDebugger SurrealCommon ${SURREALCOMMON_LIBS})
 set_target_properties(SurrealDebugger PROPERTIES CXX_STANDARD 20)
+
+if(BUILD_TESTING)
+	add_executable(PawnVisionTests SurrealEngine/Tests/PawnVisionTests.cpp)
+	target_include_directories(PawnVisionTests PRIVATE SurrealEngine)
+	set_target_properties(PawnVisionTests PROPERTIES CXX_STANDARD 20)
+	add_test(NAME PawnVisionTests COMMAND PawnVisionTests)
+endif()
 
 if(WIN32)
 	add_custom_command(TARGET SurrealEngine POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:OpenAL::OpenAL>" $<TARGET_FILE_DIR:SurrealEngine>)

--- a/SurrealEngine/Packages/Engine/Actors/Pawn/PawnVision.h
+++ b/SurrealEngine/Packages/Engine/Actors/Pawn/PawnVision.h
@@ -2,9 +2,10 @@
 
 #include "Math/vec.h"
 
-namespace PawnVision
+class PawnVision
 {
-	inline bool IsWithinVisionCone(const vec3& observerLocation, const vec3& targetLocation, const vec3& viewDirection, float peripheralVision)
+public:
+	static inline bool IsWithinVisionCone(const vec3& observerLocation, const vec3& targetLocation, const vec3& viewDirection, float peripheralVision)
 	{
 		if (!std::isfinite(peripheralVision) ||
 			!std::isfinite(observerLocation.x) || !std::isfinite(observerLocation.y) || !std::isfinite(observerLocation.z) ||
@@ -39,4 +40,4 @@ namespace PawnVision
 			1.0));
 		return cosine >= peripheralVision;
 	}
-}
+};

--- a/SurrealEngine/Packages/Engine/Actors/Pawn/PawnVision.h
+++ b/SurrealEngine/Packages/Engine/Actors/Pawn/PawnVision.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Math/vec.h"
+
+namespace PawnVision
+{
+	inline bool IsWithinVisionCone(const vec3& observerLocation, const vec3& targetLocation, const vec3& viewDirection, float peripheralVision)
+	{
+		if (!std::isfinite(peripheralVision) ||
+			!std::isfinite(observerLocation.x) || !std::isfinite(observerLocation.y) || !std::isfinite(observerLocation.z) ||
+			!std::isfinite(targetLocation.x) || !std::isfinite(targetLocation.y) || !std::isfinite(targetLocation.z) ||
+			!std::isfinite(viewDirection.x) || !std::isfinite(viewDirection.y) || !std::isfinite(viewDirection.z))
+		{
+			return false;
+		}
+
+		const double toTargetX = static_cast<double>(targetLocation.x) - observerLocation.x;
+		const double toTargetY = static_cast<double>(targetLocation.y) - observerLocation.y;
+		const double toTargetZ = static_cast<double>(targetLocation.z) - observerLocation.z;
+		const double targetLengthSquared =
+			toTargetX * toTargetX +
+			toTargetY * toTargetY +
+			toTargetZ * toTargetZ;
+		const double viewLengthSquared =
+			static_cast<double>(viewDirection.x) * viewDirection.x +
+			static_cast<double>(viewDirection.y) * viewDirection.y +
+			static_cast<double>(viewDirection.z) * viewDirection.z;
+		const double minimumLengthSquared = static_cast<double>(FLT_EPSILON) * FLT_EPSILON;
+		if (targetLengthSquared <= minimumLengthSquared || viewLengthSquared <= minimumLengthSquared)
+			return false;
+
+		const double directionDot =
+			static_cast<double>(viewDirection.x) * toTargetX +
+			static_cast<double>(viewDirection.y) * toTargetY +
+			static_cast<double>(viewDirection.z) * toTargetZ;
+		const float cosine = static_cast<float>(std::clamp(
+			directionDot / (std::sqrt(viewLengthSquared) * std::sqrt(targetLengthSquared)),
+			-1.0,
+			1.0));
+		return cosine >= peripheralVision;
+	}
+}

--- a/SurrealEngine/Packages/Engine/Actors/Pawn/UPawn.cpp
+++ b/SurrealEngine/Packages/Engine/Actors/Pawn/UPawn.cpp
@@ -1,6 +1,7 @@
 
 #include "Precomp.h"
 #include "UPawn.h"
+#include "PawnVision.h"
 #include "UPlayerPawn.h"
 #include "Packages/Core/UClass.h"
 #include "Packages/Engine/Actors/Info/ULevelInfo.h"
@@ -436,16 +437,7 @@ bool UPawn::CanSee(UActor* other)
 
 	// Cannot see if the actor is outside of the peripheral vision angles
 	vec3 orientation = Coords::Rotation(Rotation()).XAxis;
-
-	// Calculate the cosine of the vectors
-	// which is basically A dot B / (|A| * |B|), or just the dot products of the normalized versions of A and B
-	float cosine = dot(normalize(orientation), normalize(origin - eye_pos));
-	// PeripheralVision field is set dynamically during a game session
-	// (for an example, see the function UnrealShare.Bots.PreSetMovement())
-	// This can be a negative value too, which is probably set to not take it into account
-	float peripheralVision = PeripheralVision();
-
-	if (peripheralVision > 0.0f && std::abs(cosine) > peripheralVision)
+	if (!PawnVision::IsWithinVisionCone(eye_pos, origin, orientation, PeripheralVision()))
 		return false;
 
 	return FastTrace(origin, eye_pos) || FastTrace(top, eye_pos) || FastTrace(bottom, eye_pos);

--- a/SurrealEngine/Tests/PawnVisionTests.cpp
+++ b/SurrealEngine/Tests/PawnVisionTests.cpp
@@ -3,17 +3,14 @@
 #include <iostream>
 #include <limits>
 
-namespace
-{
-	int failures = 0;
+static int s_Failures = 0;
 
-	void Expect(bool condition, const char* name)
+static void Expect(bool condition, const char* name)
+{
+	if (!condition)
 	{
-		if (!condition)
-		{
-			std::cerr << "FAILED: " << name << '\n';
-			failures++;
-		}
+		std::cerr << "FAILED: " << name << '\n';
+		s_Failures++;
 	}
 }
 
@@ -50,5 +47,5 @@ int main()
 	const float largest = std::numeric_limits<float>::max();
 	Expect(PawnVision::IsWithinVisionCone(vec3(largest, 0.0f, 0.0f), vec3(-largest, 0.0f, 0.0f), -forward, 1.0f), "large finite coordinates");
 
-	return failures == 0 ? 0 : 1;
+	return s_Failures == 0 ? 0 : 1;
 }

--- a/SurrealEngine/Tests/PawnVisionTests.cpp
+++ b/SurrealEngine/Tests/PawnVisionTests.cpp
@@ -1,0 +1,54 @@
+#include "Packages/Engine/Actors/Pawn/PawnVision.h"
+
+#include <iostream>
+#include <limits>
+
+namespace
+{
+	int failures = 0;
+
+	void Expect(bool condition, const char* name)
+	{
+		if (!condition)
+		{
+			std::cerr << "FAILED: " << name << '\n';
+			failures++;
+		}
+	}
+}
+
+int main()
+{
+	const vec3 origin(0.0f);
+	const vec3 forward(1.0f, 0.0f, 0.0f);
+
+	Expect(PawnVision::IsWithinVisionCone(origin, vec3(10.0f, 0.0f, 0.0f), forward, 0.5f), "target ahead");
+	Expect(!PawnVision::IsWithinVisionCone(origin, vec3(-10.0f, 0.0f, 0.0f), forward, 0.5f), "target behind");
+
+	const vec3 target(3.0f, 4.0f, 0.0f);
+	const vec3 translation(-1000.0f, 250.0f, 75.0f);
+	const bool untranslated = PawnVision::IsWithinVisionCone(origin, target, forward, 0.5f);
+	const bool translated = PawnVision::IsWithinVisionCone(origin + translation, target + translation, forward, 0.5f);
+	Expect(untranslated, "untranslated encounter");
+	Expect(translated, "translated encounter");
+	Expect(untranslated == translated, "translation invariance");
+
+	const vec3 rearQuarter(-0.5f, std::sqrt(0.75f), 0.0f);
+	Expect(PawnVision::IsWithinVisionCone(origin, rearQuarter, forward, -0.6f), "negative threshold widens cone");
+	Expect(!PawnVision::IsWithinVisionCone(origin, vec3(-1.0f, 0.0f, 0.0f), forward, -0.6f), "negative threshold still filters behind");
+
+	Expect(PawnVision::IsWithinVisionCone(origin, target, forward, 0.6f), "inclusive angular boundary");
+	Expect(!PawnVision::IsWithinVisionCone(origin, target, forward, 0.6001f), "outside angular boundary");
+	Expect(PawnVision::IsWithinVisionCone(origin, vec3(0.0f, 1.0f, 0.0f), forward, 0.0f), "perpendicular boundary");
+	Expect(PawnVision::IsWithinVisionCone(origin, vec3(1.0f, 0.0f, 0.0f), forward, 1.0f), "narrowest threshold boundary");
+	Expect(PawnVision::IsWithinVisionCone(origin, vec3(-1.0f, 0.0f, 0.0f), forward, -1.0f), "widest threshold boundary");
+
+	Expect(!PawnVision::IsWithinVisionCone(origin, origin, forward, 0.0f), "coincident observer and target");
+	Expect(!PawnVision::IsWithinVisionCone(origin, target, vec3(0.0f), 0.0f), "zero view direction");
+	Expect(!PawnVision::IsWithinVisionCone(origin, vec3(std::numeric_limits<float>::infinity(), 0.0f, 0.0f), forward, 0.0f), "non-finite target");
+	Expect(!PawnVision::IsWithinVisionCone(origin, target, forward, std::numeric_limits<float>::quiet_NaN()), "non-finite threshold");
+	const float largest = std::numeric_limits<float>::max();
+	Expect(PawnVision::IsWithinVisionCone(vec3(largest, 0.0f, 0.0f), vec3(-largest, 0.0f, 0.0f), -forward, 1.0f), "large finite coordinates");
+
+	return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Correct the angular visibility check used by `Pawn.CanSee`.

The new calculation:

- measures the direction from the observing pawn's eye position to the target,
  rather than using the target's absolute world position;
- preserves the signed directional comparison so a target behind the pawn is
  not treated like one directly ahead;
- applies signed `PeripheralVision` cosine thresholds, including negative
  values that represent wider cones; and
- leaves the existing sight-radius and three-point line-of-sight checks
  unchanged.

The angular calculation is isolated in a small pure helper so its boundary and
degenerate cases can be tested without constructing a live level.

## Bot impact

Bot visibility no longer changes merely because the same encounter occurs in
a different part of a map. Bots also stop treating rear targets as equivalent
to forward targets, while scripts that configure a wider peripheral cone keep
that wider field instead of bypassing angular filtering entirely.

This makes bot reactions through `CanSee` directionally consistent without
adding game-specific targeting, difficulty, combat-state, or map policy.

## Validation

- Windows x64 `RelWithDebInfo` `SurrealEngine` build passes.
- `PawnVisionTests` passes 1/1 through CTest.
- Coverage includes front/behind discrimination, translation invariance,
  signed negative thresholds, inclusive angular boundaries, coincident
  positions, zero view direction, non-finite inputs, and large finite world
  coordinates.
- `git diff --check` passes.

A game-backed review is still recommended to exercise live pawn rotation,
script-set `PeripheralVision`, sight-radius rejection, and occlusion in a map.
