### PR TITLE
Use GameInfo.Difficulty to obtain the difficulty and transfer it with ClientTravel()

### DIFF
--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -154,6 +154,9 @@ void Engine::Run()
 	auto rotprop = GC::Alloc<UStructProperty>(NameString(), nullptr, ObjectFlags::NoFlags);
 
 	bool firstCall = true;
+
+	float currentZoneTimeDilation = 1.0f; // Unreal 227 allows zones to specify their own time dilations
+
 	while (!quit)
 	{
 		// Main game loop should consist of these 4 steps:
@@ -163,6 +166,9 @@ void Engine::Run()
 		// Check if there is a new map to load (next level, saved game etc.): load it if that's the case
 
 		// Tick everything
+		if (LaunchInfo.IsUnreal1_227())
+			currentZoneTimeDilation = viewport->Actor()->PlayerReplicationInfo()->PlayerZone()->ZoneTimeDilation();
+
 		float realTimeElapsed = CalcTimeElapsed();
 		float entryLevelElapsed = EntryLevel ? realTimeElapsed * clamp(EntryLevelInfo->TimeDilation() * currentZoneTimeDilation, 0.0025f, 25.0f) : 0.0f;
 		float levelElapsed = realTimeElapsed * clamp(LevelInfo->TimeDilation() * currentZoneTimeDilation, 0.0025f, 25.0f);

--- a/SurrealEngine/Engine.cpp
+++ b/SurrealEngine/Engine.cpp
@@ -164,8 +164,8 @@ void Engine::Run()
 
 		// Tick everything
 		float realTimeElapsed = CalcTimeElapsed();
-		float entryLevelElapsed = EntryLevel ? realTimeElapsed * clamp(EntryLevelInfo->TimeDilation(), 0.0025f, 25.0f) : 0.0f;
-		float levelElapsed = realTimeElapsed * clamp(LevelInfo->TimeDilation(), 0.0025f, 25.0f);
+		float entryLevelElapsed = EntryLevel ? realTimeElapsed * clamp(EntryLevelInfo->TimeDilation() * currentZoneTimeDilation, 0.0025f, 25.0f) : 0.0f;
+		float levelElapsed = realTimeElapsed * clamp(LevelInfo->TimeDilation() * currentZoneTimeDilation, 0.0025f, 25.0f);
 
 		TotalTime += realTimeElapsed;
 
@@ -582,7 +582,15 @@ void Engine::ClientTravel(const std::string& newURL, ETravelType travelType, boo
 		ClientTravelInfo.URL.AddOrReplaceOption("name=" + name);
 	}
 	else if (travelType == ETravelType::TRAVEL_Relative)
+	{
 		ClientTravelInfo.URL = UnrealURL(ClientTravelInfo.URL, url);
+		// Add difficulty if it isn't there
+		if (ClientTravelInfo.URL.GetOption("Difficulty").empty())
+		{
+			ClientTravelInfo.URL.AddOrReplaceOption("Difficulty=" + std::to_string(GameInfo->Difficulty()));
+		}
+	}
+
 	ClientTravelInfo.TravelType = travelType;
 	ClientTravelInfo.TransferItems = transferItems;
 }
@@ -1196,28 +1204,14 @@ std::string Engine::ConsoleCommand(UObject* context, const std::string& commandl
 
 		// If there isn't, try to get it from the current level's options
 		if (difficulty.empty())
-		{
 			difficulty = LevelInfo->URL.GetOption("difficulty");
-			if (!difficulty.empty())
-				url.AddOrReplaceOption("difficulty=" + difficulty);
-		}
 
-		// If there still isn't, try to figure the current difficulty out using LevelInfo
+		// If there still isn't, refer to GameInfo for difficulty
 		if (difficulty.empty())
-		{
-			if (LevelInfo->bDifficulty0())
-				difficulty = "0";
-			else if (LevelInfo->bDifficulty1())
-				difficulty = "1";
-			else if (LevelInfo->bDifficulty2())
-				difficulty = "2";
-			else if (LevelInfo->bDifficulty3())
-				difficulty = "3";
-			else
-				difficulty = "2"; // Assume "Normal" difficulty
+			difficulty = std::to_string(GameInfo->Difficulty());
 
+		if (!difficulty.empty())
 			url.AddOrReplaceOption("difficulty=" + difficulty);
-		}
 
 		for (auto& map : packages->GetMaps())
 		{
@@ -1627,6 +1621,8 @@ void Engine::OnWindowMouseDoubleclick(const Point& pos, EInputKey key)
 {
 	if (engine->dxRootWindow && engine->dxRootWindow->OnWindowMouseDoubleclick(pos, key))
 		return;
+
+	InputEvent(key, IST_Press);
 }
 
 void Engine::OnWindowMouseUp(const Point& pos, EInputKey key)


### PR DESCRIPTION
This should fix difficulty switching back to normal on level changes and handle 227's new difficulty levels.

Unreal 227 also allows ZoneInfos to have their own TimeDilations. This PR also tries to handle that in Engine::Run(). So far the only map that utilizes this is DmBeyondTheSun, which we cannot test because DynamicZoneInfo support is not yet implemented.