### PR TITLE
Fix matching function call for min

### DIFF
--- a/SurrealEngine/Video/VideoPlayer.cpp
+++ b/SurrealEngine/Video/VideoPlayer.cpp
@@ -37,7 +37,7 @@ public:
 
 	size_t ReadSamples(float* output, size_t samples) override
 	{
-		size_t count = std::min(pos + samples, Data.size()) - pos;
+		size_t count = std::min<size_t>(pos + samples, Data.size()) - pos;
 		int16_t* d = Data.data() + pos;
 		for (size_t i = 0; i < count; i++)
 		{


### PR DESCRIPTION
On MacOS Clang, the line:
```c++
size_t count = std::min(pos + samples, Data.size()) - pos;
```

Fails with:
```c++
SurrealEngine/SurrealEngine/Video/VideoPlayer.cpp:41:18: error: no matching function for call to 'min'
                size_t count = std::min(pos + samples, Data.size()) - pos;
                               ^~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:40:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('uint64_t' (aka 'unsigned long long') vs. 'size_type' (aka 'unsigned long'))
min(_LIBCPP_LIFETIMEBOUND const _Tp& __a, _LIBCPP_LIFETIMEBOUND const _Tp& __b)
^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/min.h:51:1: note: candidate template ignored: could not match 'initializer_list<_Tp>' against 'uint64_t' (aka 'unsigned long long')
min(initializer_list<_Tp> __t, _Compare __comp)
```

So add a cast to std::min to please the compiler

Compiler used:
```
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```