### PR TITLE
Increase minimum CMake version for OpenAL

### DIFF
--- a/Thirdparty/openal-soft/CMakeLists.txt
+++ b/Thirdparty/openal-soft/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file list for OpenAL
 
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5.0)
 
 if(APPLE)
     # The workaround for try_compile failing with code signing


### PR DESCRIPTION
Since CMake 4+ dropped the compatibility with pre-3.5.0 CMake, raise the minmum version to 3.5.0.