### PR TITLE
Add exception unrolling for macOS

### DIFF
--- a/SurrealEngine/Utils/Exception.cpp
+++ b/SurrealEngine/Utils/Exception.cpp
@@ -35,7 +35,7 @@ struct InitDbgHelp
 	bool bHasSymbols;
 };
 
-#elif defined __linux__
+#elif defined __linux__ || defined __APPLE__
 
 #include <execinfo.h>
 #include <cxxabi.h>
@@ -129,6 +129,70 @@ int Exception::CaptureStackFrames(std::ostringstream& sstream, int maxframes)
 
 	return frame;
 
+
+/////////////////////////////////////////////////////////////////////
+#elif defined __APPLE__
+
+	if (maxframes <= 0)
+		return 0;
+
+	std::vector<void*> frames(static_cast<size_t>(maxframes));
+	const int frameCount = backtrace(frames.data(), maxframes);
+	if (frameCount <= 2)
+		return 0;
+
+	using SymbolList = std::unique_ptr<char*, decltype(&std::free)>;
+	SymbolList symbols(backtrace_symbols(frames.data(), frameCount), &std::free);
+	if (!symbols)
+		return 0;
+
+	auto formatSymbol = [](const char* rawSymbol)
+	{
+		if (!rawSymbol)
+			return std::string("<unknown>");
+
+		std::string symbol(rawSymbol);
+		const size_t offsetPos = symbol.rfind(" + ");
+		const size_t addressPos = symbol.find("0x");
+
+		if (offsetPos == std::string::npos || addressPos == std::string::npos)
+			return symbol;
+
+		const size_t addressEnd = symbol.find_first_of(" \t", addressPos);
+		if (addressEnd == std::string::npos)
+			return symbol;
+
+		const size_t nameBegin = symbol.find_first_not_of(" \t", addressEnd);
+		if (nameBegin == std::string::npos || nameBegin >= offsetPos)
+			return symbol;
+
+		std::string functionName = symbol.substr(nameBegin, offsetPos - nameBegin);
+		std::string mangledName = functionName;
+
+		// Mach-O symbols have some underscores
+		if (mangledName.compare(0, 3, "__Z") == 0)
+			mangledName.erase(0, 1);
+
+		if (mangledName.compare(0, 2, "_Z") == 0)
+		{
+			int status = 0;
+			std::unique_ptr<char, decltype(&std::free)> demangled(
+				abi::__cxa_demangle(mangledName.c_str(), nullptr, nullptr, &status),
+				&std::free);
+
+			if (status == 0 && demangled)
+				functionName = demangled.get();
+		}
+
+		return functionName + symbol.substr(offsetPos);
+	};
+
+	for (size_t frame = 0; frame < frameCount; frame++)
+	{
+		sstream << "at " << formatSymbol(symbols.get()[frame]) << std::endl;
+	}
+
+	return frameCount;
 
 /////////////////////////////////////////////////////////////////////
 #else


### PR DESCRIPTION
Add a simple exception unrolling for macOS, this could be used with atos/addr2line to know where it crashes.

It may be modified to work on Linux with few modification, untested.

Sample:
```
$ ./SurrealEngine.app/Contents/MacOS/SurrealEngine $(pwd)/app
Could not open SurrealEngine.pk3
at Exception::CaptureStackFrames(std::__1::basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, int) + 88
at Exception::Throw(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 336
at ResourceLoaderPK3::ResourceLoaderPK3() + 1576
at InitWidgetResources() + 32
at GameApp::main(Array<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>) + 92
at main + 304
at start + 2360
```