### PR TITLE
Change handling of SE.pk3 resource for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1101,7 +1101,22 @@ if(WIN32)
 	add_custom_command(TARGET SurrealEngine POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:OpenAL::OpenAL>" $<TARGET_FILE_DIR:SurrealEngine>)
 endif()
 
-add_custom_command(TARGET SurrealEngine POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/SurrealEngine.pk3" $<TARGET_FILE_DIR:SurrealEngine>)
+if(APPLE)
+	foreach(bundle_target SurrealEngine SurrealEditor)
+		add_custom_command(TARGET ${bundle_target} POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_BUNDLE_DIR:${bundle_target}>/Contents/Resources"
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+				"${CMAKE_CURRENT_SOURCE_DIR}/SurrealEngine.pk3"
+				"$<TARGET_BUNDLE_DIR:${bundle_target}>/Contents/Resources"
+		)
+	endforeach()
+else()
+	add_custom_command(TARGET SurrealEngine POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			"${CMAKE_CURRENT_SOURCE_DIR}/SurrealEngine.pk3"
+			$<TARGET_FILE_DIR:SurrealEngine>
+	)
+endif()
 
 if(MSVC)
 	# Create stripped PDBs for nightly builds

--- a/SurrealEngine/Utils/File.cpp
+++ b/SurrealEngine/Utils/File.cpp
@@ -396,7 +396,7 @@ std::string OS::executable_path()
 	CFBundleRef mainBundle = CFBundleGetMainBundle();
 	if (mainBundle)
 	{
-		CFURLRef mainURL = CFBundleCopyBundleURL(mainBundle);
+		CFURLRef mainURL = CFBundleCopyResourcesDirectoryURL(mainBundle);
 
 		if (mainURL)
 		{


### PR DESCRIPTION
SurrealEngine and SurrealEditor are built as macOS application bundles. CMake’s $<TARGET_FILE_DIR:...> generator expression resolves to `<App>.app/Contents/MacOS` However, the macOS implementation of OS::executable_path() use CFBundleCopyBundleURL(), which returns to the bundle root.

So, the resource loader searched for: `<App>.app/SurrealEngine.pk3`, which is invalid of course.

Instead, on macOS, copy SurrealEngine.pk3 into the conventional bundle resource directory and change the lookup for CFBundleCopyResourcesDirectoryURL.

Of course, keep the old behavior for Linux/Windows.