### PR TITLE
Remove malloc.h in pffft

### DIFF
--- a/Thirdparty/resample/pffft.cpp
+++ b/Thirdparty/resample/pffft.cpp
@@ -75,7 +75,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#include <malloc.h>
 
 #if defined(COMPILER_GCC)
 #  define ALWAYS_INLINE(return_type) inline return_type __attribute__ ((always_inline))


### PR DESCRIPTION
The malloc.h header is available on Linux and Windows but is not present on macOS. Since the library only uses the vanilla malloc present in stdlib, it's not needed on Linux, Windows or on macOS.